### PR TITLE
Cocoapods support

### DIFF
--- a/MyDataHelpsKit.podspec
+++ b/MyDataHelpsKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = "MyDataHelpsKit"
-  spec.version = '1.0' #auto-generated
+  spec.version = '1.0.0' #auto-generated
   spec.summary = "An SDK to integrate RKStudio™ with your apps to develop your own participant experiences"
   spec.homepage = "https://github.com/CareEvolution/MyDataHelpsKit-iOS"
   spec.documentation_url = "https://developer.rkstudio.careevolution.com"

--- a/MyDataHelpsKit.podspec
+++ b/MyDataHelpsKit.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+
+  spec.name = "MyDataHelpsKit"
+  spec.version = '1.0' #auto-generated
+  spec.summary = "An SDK to integrate RKStudio™ with your apps to develop your own participant experiences"
+  spec.homepage = "https://developer.rkstudio.careevolution.com"
+  spec.license = { :type => "Apache", :file => "LICENSE" }
+  spec.author = "CareEvolution, LLC"
+
+  spec.swift_version = '5.0' #auto-generated
+  spec.ios.deployment_target = '11.0' #auto-generated
+
+  spec.source = { :git => "https://github.com/CareEvolution/MyDataHelpsKit-iOS.git", :tag => "#{spec.version}" }
+
+  spec.source_files = "MyDataHelpsKit/**/*.{swift,h}"
+
+end

--- a/MyDataHelpsKit.podspec
+++ b/MyDataHelpsKit.podspec
@@ -3,7 +3,8 @@ Pod::Spec.new do |spec|
   spec.name = "MyDataHelpsKit"
   spec.version = '1.0' #auto-generated
   spec.summary = "An SDK to integrate RKStudio™ with your apps to develop your own participant experiences"
-  spec.homepage = "https://developer.rkstudio.careevolution.com"
+  spec.homepage = "https://github.com/CareEvolution/MyDataHelpsKit-iOS"
+  spec.documentation_url = "https://developer.rkstudio.careevolution.com"
   spec.license = { :type => "Apache", :file => "LICENSE" }
   spec.author = "CareEvolution, LLC"
 

--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AC77B4C125E8495C00427294 /* Build configuration list for PBXNativeTarget "MyDataHelpsKit" */;
 			buildPhases = (
-				ACC2EB9326124D3F0080A3B5 /* Set SDKVersion */,
+				ACC2EB9326124D3F0080A3B5 /* Update SDKVersion and podspec */,
 				AC77B4B425E8495C00427294 /* Headers */,
 				AC77B4B525E8495C00427294 /* Sources */,
 				AC77B4B625E8495C00427294 /* Frameworks */,
@@ -288,7 +288,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		ACC2EB9326124D3F0080A3B5 /* Set SDKVersion */ = {
+		ACC2EB9326124D3F0080A3B5 /* Update SDKVersion and podspec */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -297,14 +297,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Set SDKVersion";
+			name = "Update SDKVersion and podspec";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"// Automatically generated\\nlet MyDataHelpsKitVersion = \\\"${MARKETING_VERSION}\\\"\" > \"${PROJECT_DIR}/MyDataHelpsKit/SDKVersion.swift\"\n";
+			shellScript = "# Update SDKVersion.swift constant\n\necho \"// Automatically generated\\nlet MyDataHelpsKitVersion = \\\"${MARKETING_VERSION}\\\"\" > \"${PROJECT_DIR}/MyDataHelpsKit/SDKVersion.swift\"\n\n# Update podspec file\n\npattern='^ *spec.version = .*$'\nsed -I '' -e \"s/${pattern}/  spec.version = '${MARKETING_VERSION}' #auto-generated/g\" MyDataHelpsKit.podspec\n\npattern='^ *spec.swift_version = .*$'\nsed -I '' -e \"s/${pattern}/  spec.swift_version = '${SWIFT_VERSION}' #auto-generated/g\" MyDataHelpsKit.podspec\n\npattern='^ *spec.ios.deployment_target = .*$'\nsed -I '' -e \"s/${pattern}/  spec.ios.deployment_target = '${IPHONEOS_DEPLOYMENT_TARGET}' #auto-generated/g\" MyDataHelpsKit.podspec\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.CareEvolution.MyDataHelpsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -531,7 +531,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.CareEvolution.MyDataHelpsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MyDataHelpsKit/SDKVersion.swift
+++ b/MyDataHelpsKit/SDKVersion.swift
@@ -1,2 +1,2 @@
 // Automatically generated
-let MyDataHelpsKitVersion = "1.0"
+let MyDataHelpsKitVersion = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,22 @@ Use the [standard Carthage workflow](https://github.com/Carthage/Carthage#adding
 2. Run `carthage update --use-xcframeworks`
 3. Open your app target's General settings tab in Xcode. In Finder, go to the `Carthage/Build` folder, and drag and drop `MyDataHelpsKit.xcframework` from the `Carthage/Build` folder into the "Frameworks, Libraries, and Embedded Content" section in Xcode
 
+To update MyDataHelpsKit to a newer version, run `carthage update --use-xcframeworks`, optionally appending MyDataHelpsKit-iOS to the command to only update this SDK and not other Carthage dependencies.
+
+### Cocoapods
+
+Use the [standard Cocoapods workflow](https://guides.cocoapods.org/using/using-cocoapods.html):
+
+1. Create a Podfile for your project using `pod init` if needed
+2. Add `pod 'MyDataHelpsKit'` to your Podfile
+3. Run `pod install`
+
+To update MyDataHelpsKit to a newer version, run `pod update`, optionally appending MyDataHelpsKit to the command to only update this SDK and not other Cocoapods dependencies.
+
 ### Manual integration
 
 1. Download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases)
 2. From Finder, drag `MyDataHelpsKit.xcodeproj`  into your app's Xcode workspace
 3. Open your app target's General settings tab in Xcode. In the project navigator pane, expand MyDataHelpsKit.xcodeproj > Products and drag MyDataHelpsKit.framework into the "Frameworks, Libraries, and Embedded Content" section 
+
+To update to a newer version of MyDataHelpsKit, download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases), and then delete and replace the existing MyDataHelpsKit folder structure in your workspace.


### PR DESCRIPTION
See #3 

Creates podspec file, and adds some Xcode build scripts to automatically keep some version numbers in the podspec file up-to-date with Xcode project settings.

I wrote some documentation on the [rkstudioapi-docs wiki](https://github.com/CareEvolution/rkstudioapi-docs/wiki/Cocoapods).

## Testing

Following https://guides.cocoapods.org/using/using-cocoapods.html:

1. Create a new empty Xcode project
2. In terminal, cd to the project directory (same directory the xcodeproj lives in)
3. Run `pod init`
4. Edit `Podfile`, add `pod 'MyDataHelpsKit', :git => 'https://github.com/CareEvolution/MyDataHelpsKit-iOS.git', :branch => 'mmertsock/podspec'` for testing directly against this branch
5. Run `pod install`
6. Open the xcworkspace in Xcode. You should be able to `import MyDataHelpsKit` and write code using the SDK

When published to Cocoapods trunk, clients can just use `pod 'MyDataHelpsKit'` for step 4.