### PR TITLE
Example app fixes

### DIFF
--- a/example/MyDataHelpsKit-Example/ContentView.swift
+++ b/example/MyDataHelpsKit-Example/ContentView.swift
@@ -18,12 +18,8 @@ struct ContentView: View {
                     .navigationTitle(title)
                     .navigationBarItems(trailing: Button("Log Out", action: logOut))
             } else {
-                VStack(alignment: .leading) {
-                    Text("Log In")
-                        .font(.headline)
-                    TokenView()
-                }.padding()
-                .navigationTitle(title)
+                TokenView()
+                    .navigationTitle(title)
             }
         }
     }

--- a/example/MyDataHelpsKit-Example/PagedView/DeviceDataPointView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/DeviceDataPointView.swift
@@ -10,7 +10,7 @@ import MyDataHelpsKit
 
 struct DeviceDataPointView: View {
     static func pageView(session: ParticipantSessionType, namespace: DeviceDataNamespace, types: Set<String>?) -> PagedView<DeviceDataSource, DeviceDataPointView> {
-        let query = DeviceDataQuery(namespace: namespace, types: types)
+        let query = DeviceDataQuery(namespace: namespace, types: types, limit: 25)
         let source = DeviceDataSource(session: session, query: query)
         return PagedView(model: .init(source: source) { item in
             DeviceDataPointView(model: item)

--- a/example/MyDataHelpsKit-Example/PagedView/PagedViewModel.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/PagedViewModel.swift
@@ -21,57 +21,58 @@ protocol PagedModelSource {
 }
 
 class PagedViewModel<SourceType: PagedModelSource, ItemViewType: View>: ObservableObject {
+    typealias ItemType = SourceType.PageModel.ItemType
+    
     enum State {
-        case ready
-        case loading
-        case done
-        case failed(MyDataHelpsError)
+        case normal(loadMore: Bool)
+        case empty
+        case failure(MyDataHelpsError)
     }
     
     let source: SourceType
-    let viewProvider: (SourceType.PageModel.ItemType) -> ItemViewType
-    
-    private var lastPage: SourceType.PageModel? {
-        didSet {
-            if let lastPage = lastPage {
-                items.append(contentsOf: lastPage.pageItems(session: source.session))
-            }
-        }
-    }
+    let viewProvider: (ItemType) -> ItemViewType
+    private var loading: Bool
+    private var lastPage: SourceType.PageModel?
     
     @Published var state: State
-    @Published var items: [SourceType.PageModel.ItemType]
-    
-    init(source: SourceType, viewProvider: @escaping (SourceType.PageModel.ItemType) -> ItemViewType) {
+    @Published var items: [ItemType]
+
+    init(source: SourceType, viewProvider: @escaping (ItemType) -> ItemViewType) {
         self.source = source
         self.viewProvider = viewProvider
         self.lastPage = nil
-        self.state = .ready
+        self.state = .normal(loadMore: true)
         self.items = []
-    }
-    
-    func loadFirstPage() {
-        lastPage = nil
-        state = .ready
-        items = []
+        self.loading = false
         loadNextPage()
     }
     
     func loadNextPage() {
-        guard case .ready = state else { return }
-        state = .loading
+        guard case .normal(true) = state, !loading else { return }
+        
+        loading = true
         source.loadPage(after: lastPage) { [weak self] result in
             switch result {
             case let .success(page):
-                self?.lastPage = page
-                self?.state = page.nextPageID == nil ? .done : .ready
+                self?.loaded(page)
             case let .failure(error):
-                self?.state = .failed(error)
+                self?.state = .failure(error)
             }
+            self?.loading = false
         }
     }
     
-    func isLastItem(_ item: SourceType.PageModel.ItemType) -> Bool {
+    func isLastItem(_ item: ItemType) -> Bool {
         item.id == items.last?.id
+    }
+    
+    private func loaded(_ page: SourceType.PageModel) {
+        lastPage = page
+        items.append(contentsOf: page.pageItems(session: source.session))
+        if items.isEmpty {
+            state = .empty
+        } else {
+            state = .normal(loadMore: page.nextPageID != nil)
+        }
     }
 }

--- a/example/MyDataHelpsKit-Example/Session/RootMenuView.swift
+++ b/example/MyDataHelpsKit-Example/Session/RootMenuView.swift
@@ -43,7 +43,7 @@ struct RootMenuView: View {
             }
             
             NavigationLink(
-                destination: DeviceDataPointView.pageView(session: participant.session, namespace: .appleHealth, types: Set(["HeartRate"]))
+                destination: DeviceDataPointView.pageView(session: participant.session, namespace: .appleHealth, types: Set(["StandHourInterval"]))
                     .navigationTitle("Query Device Data")
             ) {
                 Label("Device Data: Apple Health", systemImage: "heart")

--- a/example/MyDataHelpsKit-Example/Session/TokenView.swift
+++ b/example/MyDataHelpsKit-Example/Session/TokenView.swift
@@ -11,12 +11,19 @@ struct TokenView: View {
     @EnvironmentObject var sessionModel: SessionModel
     
     var body: some View {
-        HStack {
-            TextField("Participant Token", text: $sessionModel.token)
-            Button(action: useToken, label: {
-                Image(systemName: "person.crop.circle.badge.checkmark")
-            })
-        }
+        VStack {
+            Text("To get started with this example app, you need a participant access token. Paste the participant access token below to initialize the app with a ParticipantSession and access views that demonstracte the functionality provided by MyDataHelpsKit.\n\nSee MyDataHelpsKit documentaion for more information.")
+                .font(.subheadline)
+            Spacer()
+            Text("Participant access token:")
+                .font(.headline)
+            HStack {
+                TextField("Token", text: $sessionModel.token)
+                Button(action: useToken, label: {
+                    Image(systemName: "person.crop.circle.badge.checkmark")
+                })
+            }
+        }.padding()
     }
     
     private func useToken() {


### PR DESCRIPTION
*This pull request makes no changes to the SDK itself, and there are no documentation updates. All changes are for the example app included in this repo.*

Adds some instructional text upon app launch to explain that you need to obtain a participant token to use the example app.

Sets limit:25 for device data point query to better demonstrate PagedView/infinite scrolling behavior.

Switches the HealthKit device data point query to use standing hours instead of heart rate — I found that to be a better choice (and less personal) for recent demos.

Fixes a problem with PagedViews endlessly reloading the first page. There appears to be a SwiftUI bug that triggers `onAppear` to fire more than once in certain cases, which combined with PagedViewModel.loadFirstPage resetting the model's state, caused the looping behavior. I fixed the bug by loading the first page exactly once during PagedViewModel.init.

Also did some general refactoring of PagedView/PagedViewModel for cleaner, less error-prone code and some UI enhancements:
- When there are zero results, shows some text indicating that instead of an empty list view
- The PagedViewModel.State refactor allows the PagedView to correctly show the existing list of items while loading additional pages, and thus avoids flickering and resetting the scroll position while loading additional pages
- Added a ProgressView that appears at the bottom of the list while loading additional pages