### PR TITLE
enrollmentDate, tweak example app UI, fix typos

### DIFF
--- a/MyDataHelpsKit/Model/ParticipantInfo.swift
+++ b/MyDataHelpsKit/Model/ParticipantInfo.swift
@@ -19,6 +19,8 @@ public struct ParticipantInfo: Decodable {
     public let demographics: ParticipantDemographics
     /// Key/value pairs representing project-specific custom fields.
     public let customFields: [String: String]
+    /// Date when the participant completed enrollment.
+    public let enrollmentDate: Date?
 }
 
 /// Participant's gender.

--- a/example/MyDataHelpsKit-Example/ContentView.swift
+++ b/example/MyDataHelpsKit-Example/ContentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import MyDataHelpsKit
 
 struct ContentView: View {
     @EnvironmentObject var sessionModel: SessionModel
@@ -15,17 +14,13 @@ struct ContentView: View {
         NavigationView {
             if let session = sessionModel.session {
                 RootMenuView(participant: .init(session: session))
-                    .navigationTitle(title)
+                    .navigationTitle("Example App")
                     .navigationBarItems(trailing: Button("Log Out", action: logOut))
             } else {
                 TokenView()
-                    .navigationTitle(title)
+                    .navigationTitle("Example App")
             }
         }
-    }
-    
-    var title: String {
-        "MyDataHelpsKit v\(MyDataHelpsClient.SDKVersion)"
     }
     
     private func logOut() {

--- a/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
@@ -12,6 +12,7 @@ struct ParticipantInfoViewModel {
     let name: String
     let email: String?
     let phone: String?
+    let enrollmentDate: Date?
 }
 
 extension ParticipantInfoViewModel {
@@ -21,11 +22,19 @@ extension ParticipantInfoViewModel {
         self.name = tokens.compactMap { $0 }.joined(separator: " ")
         self.email = info.demographics.email
         self.phone = info.demographics.mobilePhone
+        self.enrollmentDate = info.enrollmentDate
     }
 }
 
 struct ParticipantInfoView: View {
     let model: ParticipantInfoViewModel
+    
+    private static let dateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df
+    }()
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -37,6 +46,9 @@ struct ParticipantInfoView: View {
             if let phone = model.phone {
                 Text(phone)
             }
+            if let enrollmentDate = model.enrollmentDate {
+                Text("Enrolled \(Self.dateFormatter.string(from: enrollmentDate))")
+            }
         }
         .font(.caption)
     }
@@ -46,8 +58,9 @@ struct ParticipantInfoView_Previews: PreviewProvider {
     static var previews: some View {
         ParticipantInfoView(
             model: .init(
-                name: "Firstname Lastname",
+                name: "FirstName LastName",
                 email: nil,
-                phone: "555-555-1212"))
+                phone: "555-555-1212",
+                enrollmentDate: Date().addingTimeInterval(-86400)))
     }
 }

--- a/example/MyDataHelpsKit-Example/Session/ParticipantModel.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantModel.swift
@@ -30,7 +30,7 @@ extension ParticipantSession: ParticipantSessionType {
 
 class ParticipantSessionPreview: ParticipantSessionType {
     func getParticipantInfoViewModel(completion: @escaping (Result<ParticipantInfoViewModel, MyDataHelpsError>) -> Void) {
-        completion(.success(.init(name: "name", email: "email", phone: "phone")))
+        completion(.success(.init(name: "name", email: "email", phone: "phone", enrollmentDate: Date())))
     }
     
     func queryDeviceData(_ query: DeviceDataQuery, completion: @escaping (Result<DeviceDataResultPage, MyDataHelpsError>) -> Void) {

--- a/example/MyDataHelpsKit-Example/Session/TokenView.swift
+++ b/example/MyDataHelpsKit-Example/Session/TokenView.swift
@@ -6,13 +6,17 @@
 //
 
 import SwiftUI
+import MyDataHelpsKit
 
 struct TokenView: View {
     @EnvironmentObject var sessionModel: SessionModel
     
     var body: some View {
-        VStack {
-            Text("To get started with this example app, you need a participant access token. Paste the participant access token below to initialize the app with a ParticipantSession and access views that demonstracte the functionality provided by MyDataHelpsKit.\n\nSee MyDataHelpsKit documentaion for more information.")
+        VStack(alignment: .leading) {
+            Text("MyDataHelpsKit v\(MyDataHelpsClient.SDKVersion)")
+                .font(.headline)
+                .padding(.bottom)
+            Text("To get started with this example app, you need a participant access token. Paste the participant access token below to initialize the app with a ParticipantSession and access views that demonstrate the functionality provided by MyDataHelpsKit.\n\nSee MyDataHelpsKit documentation for more information.")
                 .font(.subheadline)
             Spacer()
             Text("Participant access token:")
@@ -33,7 +37,10 @@ struct TokenView: View {
 
 struct TokenView_Previews: PreviewProvider {
     static var previews: some View {
-        TokenView()
-            .environmentObject(SessionModel())
+        NavigationView {
+            TokenView()
+                .navigationTitle("Example App")
+                .environmentObject(SessionModel())
+        }
     }
 }


### PR DESCRIPTION
Closes #11. The only SDK change here is adding `enrollmentDate` to ParticipantInfo. The other changes are all in the example app.

The string "MyDataHelpsKit vX.X.X" in the example app nav bar title was too long and getting truncated, so I moved it to a heading-style label in TokenView (the first view displayed when launching the app).