### PR TITLE
Release 1.0.1

### DIFF
--- a/MyDataHelpsKit.podspec
+++ b/MyDataHelpsKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = "MyDataHelpsKit"
-  spec.version = '1.0.0' #auto-generated
+  spec.version = '1.0.1' #auto-generated
   spec.summary = "An SDK to integrate RKStudio™ with your apps to develop your own participant experiences"
   spec.homepage = "https://github.com/CareEvolution/MyDataHelpsKit-iOS"
   spec.documentation_url = "https://developer.rkstudio.careevolution.com"

--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.CareEvolution.MyDataHelpsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -531,7 +531,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.CareEvolution.MyDataHelpsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MyDataHelpsKit/SDKVersion.swift
+++ b/MyDataHelpsKit/SDKVersion.swift
@@ -1,2 +1,2 @@
 // Automatically generated
-let MyDataHelpsKitVersion = "1.0.0"
+let MyDataHelpsKitVersion = "1.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
     targets: [
         .target(
             name: "MyDataHelpsKit",
-            path: "MyDataHelpsKit"
+            path: "MyDataHelpsKit",
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "MyDataHelpsKitTests",

--- a/example/MyDataHelpsKit-Example.xcodeproj/project.pbxproj
+++ b/example/MyDataHelpsKit-Example.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.MyDataHelpsKit-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -424,7 +424,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.MyDataHelpsKit-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
See #10

Also, a framework's Info.plist file is not used in Swift packages. The Package.swift change here fixes the following warning when importing the Swift package:

> found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
