### PR TITLE
Embeddable surveys

### DIFF
--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AC83ABCD25E991E300A668E4 /* PagedQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC83ABCC25E991E300A668E4 /* PagedQuery.swift */; };
 		AC83ABDC25F131DA00A668E4 /* URLRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC83ABDB25F131DA00A668E4 /* URLRequestsTests.swift */; };
 		AC83ABDE25F131DA00A668E4 /* MyDataHelpsKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC77B4B925E8495C00427294 /* MyDataHelpsKit.framework */; };
+		AC932351265D9874007AAF69 /* EmbeddableSurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC932350265D9874007AAF69 /* EmbeddableSurveyViewController.swift */; };
 		AC9DC9A026052AEA00C5D9E4 /* SurveyAnswers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9DC99F26052AEA00C5D9E4 /* SurveyAnswers.swift */; };
 		AC9DC9A42605359300C5D9E4 /* SurveyAnswersQueryResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9DC9A32605359300C5D9E4 /* SurveyAnswersQueryResource.swift */; };
 		AC9DC9AA2605408600C5D9E4 /* DeleteSurveyResultResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9DC9A92605408600C5D9E4 /* DeleteSurveyResultResource.swift */; };
@@ -68,6 +69,7 @@
 		AC83ABD925F131DA00A668E4 /* MyDataHelpsKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MyDataHelpsKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC83ABDB25F131DA00A668E4 /* URLRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestsTests.swift; sourceTree = "<group>"; };
 		AC83ABDD25F131DA00A668E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AC932350265D9874007AAF69 /* EmbeddableSurveyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddableSurveyViewController.swift; sourceTree = "<group>"; };
 		AC9DC9782604EFF700C5D9E4 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		AC9DC99F26052AEA00C5D9E4 /* SurveyAnswers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnswers.swift; sourceTree = "<group>"; };
 		AC9DC9A32605359300C5D9E4 /* SurveyAnswersQueryResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyAnswersQueryResource.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 			children = (
 				AC77B51325E8575A00427294 /* API */,
 				AC02E69B25FAA979008A46E4 /* Diagnostics.swift */,
+				AC93234F265D4005007AAF69 /* Embeddables */,
 				AC77B4BD25E8495C00427294 /* Info.plist */,
 				AC77B50625E852EE00427294 /* Model */,
 				AC77B50025E8502000427294 /* MyDataHelpsClient.swift */,
@@ -180,6 +183,14 @@
 				AC83ABDB25F131DA00A668E4 /* URLRequestsTests.swift */,
 			);
 			path = MyDataHelpsKitTests;
+			sourceTree = "<group>";
+		};
+		AC93234F265D4005007AAF69 /* Embeddables */ = {
+			isa = PBXGroup;
+			children = (
+				AC932350265D9874007AAF69 /* EmbeddableSurveyViewController.swift */,
+			);
+			path = Embeddables;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -240,7 +251,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					AC77B4B825E8495C00427294 = {
 						CreatedOnToolsVersion = 12.4;
@@ -322,6 +333,7 @@
 				AC02E68425FA7FCD008A46E4 /* SurveyTasks.swift in Sources */,
 				AC02E68825FA8056008A46E4 /* SurveyTaskQueryResource.swift in Sources */,
 				AC9DC9BA2609198700C5D9E4 /* NotificationHistoryQueryResource.swift in Sources */,
+				AC932351265D9874007AAF69 /* EmbeddableSurveyViewController.swift in Sources */,
 				AC77B50125E8502000427294 /* MyDataHelpsClient.swift in Sources */,
 				AC83ABB925E867E100A668E4 /* DeviceDataQueryResource.swift in Sources */,
 				AC83ABB125E85BB900A668E4 /* GetParticipantInfoResource.swift in Sources */,

--- a/MyDataHelpsKit.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit.xcscheme
+++ b/MyDataHelpsKit.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MyDataHelpsKit/API/URLRequests.swift
+++ b/MyDataHelpsKit/API/URLRequests.swift
@@ -89,13 +89,7 @@ extension ParticipantSession {
         request.setValue("Bearer \(accessToken.token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(client.userAgent, forHTTPHeaderField: "User-Agent")
-        
-        var acceptLanguage = Locale.current.languageCode ?? "en"
-        if let regionCode = Locale.current.regionCode {
-            acceptLanguage += "-\(regionCode)"
-        }
-        request.setValue(acceptLanguage, forHTTPHeaderField: "Accept-Language")
-        
+        request.setValue(client.languageTag, forHTTPHeaderField: "Accept-Language")
         return request
     }
 }

--- a/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
+++ b/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
@@ -132,6 +132,9 @@ public final class EmbeddableSurveyViewController: UIViewController {
     
     private func checkForLoadingTimeout() {
         if case .loading = viewState {
+            if let webView = view as? WKWebView {
+                webView.stopLoading()
+            }
             complete(.failure(.webContentError(nil)))
         }
     }

--- a/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
+++ b/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
@@ -1,0 +1,235 @@
+//
+//  EmbeddableSurveyViewController.swift
+//  MyDataHelpsKit
+//
+//  Created by CareEvolution on 5/25/21.
+//
+
+import UIKit
+import WebKit
+
+/// Presents a MyDataHelps embeddable survey or task inside a web view. This view controller implements the complete user experience for a MyDataHelps survey, including step navigation, sending results to RKStudio, etc., and is intended for modal presentation.
+///
+/// ## Enabling MyDataHelps embeddable surveys in RKStudio
+///
+/// In order to use EmbeddableSurveyViewController to present a MyDataHelps embeddable survey, this feature must be enabled for both the project and the survey in RKStudio:
+/// - Enable "Allow Survey Completion Via Link" in project settings
+/// - Enable "Allow Task Completion Via Link" and/or "Allow Survey Completion Via Link" in survey settings
+///
+/// See [Completing Surveys with Survey Links](https://rkstudio-support.careevolution.com/hc/en-us/articles/360036515193-Completing-Surveys-with-Survey-Links) for more information.
+///
+/// ## Initializing and presenting
+///
+/// Create an EmbeddableSurveyViewController using one of its `init` methods, identifying the participant by their `participantLinkIdentifier` and the survey or task by `surveyName` or `taskLinkIdentifier`.
+///
+/// For the best user experience, present this view controller modally, and do not wrap it in a UINavigationController, etc. The embedded survey content itself will display all of the controls necessary for navigation, such as localized Cancel/Done buttons.
+///
+/// ## Completion and dismissal
+///
+/// Once the participant has finished interacting with the survey, EmbeddableSurveyViewController will invoke the `completion` callback. The view controller will not dismiss itself. In all cases — success and failure — the completion callback _must_ dismiss the EmbeddableSurveyViewController.
+///
+/// Use the `Result` object sent to the completion callback to determine whether the survey interaction was successful or failed. If the result is a `failure`, consider displaying an error alert to the user.
+public final class EmbeddableSurveyViewController: UIViewController {
+    private enum State {
+        /// The web view is not yet loading the survey.
+        case uninitialized
+        /// The web view is loading the survey/DOM initialization is in process.
+        case loading(WKNavigation?)
+        /// Survey is presented on-screen and ready for user interaction.
+        case ready
+        /// User interaction is complete. Completion callback has been invoked
+        case completed
+    }
+    
+    private static let timeoutIntervalSeconds = 15
+    private let surveyURL: Result<URL, MyDataHelpsError>
+    private let languageTag: String
+    private let userAgent: String
+    private let completion: (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void
+    
+    private var viewState: State
+    
+    /// Initializes an EmbeddableSurveyViewController that will display a survey task assigned to a participant.
+    /// - Parameters:
+    ///   - client: The client through which to access the embedded survey.
+    ///   - taskLinkIdentifier: Identifies the survey task to present to the participant. This is the `linkIdentifier` property of `SurveyTask`, as retrieved via `ParticipantSession.querySurveyTasks`.
+    ///   - participantLinkIdentifier: Auto-generated participant identifier used to complete surveys via link. This is the `linkIdentifier` property of `ParticipantInfo`, as retrieved via `ParticipantSession.getParticipantInfo`.
+    ///   - completion: Called when the participant has completed interaction with the survey. The completion callback must always dismiss the EmbeddableSurveyViewController.
+    public init(client: MyDataHelpsClient, taskLinkIdentifier: String, participantLinkIdentifier: String, completion: @escaping (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void) {
+        self.surveyURL = client.embeddableSurveyURL(taskLinkIdentifier: taskLinkIdentifier, participantLinkIdentifier: participantLinkIdentifier)
+        self.languageTag = client.languageTag
+        self.userAgent = client.userAgent
+        self.completion = completion
+        self.viewState = .uninitialized
+        super.init(nibName: nil, bundle: nil)
+        if #available(iOS 13.0, *) {
+            self.isModalInPresentation = true
+        }
+    }
+    
+    /// Initializes an EmbeddableSurveyViewController that will display a survey identified by name.
+    /// - Parameters:
+    ///   - client: The client through which to access the embedded survey.
+    ///   - surveyName: The name of the survey to present.
+    ///   - participantLinkIdentifier: Auto-generated participant identifier used to complete surveys via link. This is the `linkIdentifier` property of `ParticipantInfo`, as retrieved via `ParticipantSession.getParticipantInfo`.
+    ///   - completion: Called when the participant has completed interaction with the survey. The completion callback must always dismiss the EmbeddableSurveyViewController.
+    public init(client: MyDataHelpsClient, surveyName: String, participantLinkIdentifier: String, completion: @escaping (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void) {
+        self.surveyURL = client.embeddableSurveyURL(surveyName: surveyName, participantLinkIdentifier: participantLinkIdentifier)
+        self.languageTag = client.languageTag
+        self.userAgent = client.userAgent
+        self.completion = completion
+        self.viewState = .uninitialized
+        super.init(nibName: nil, bundle: nil)
+        if #available(iOS 13.0, *) {
+            self.isModalInPresentation = true
+        }
+    }
+    
+    /// Not implemented.
+    /// - Parameter coder: An unarchiver object.
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not implemented")
+    }
+    
+    /// Creates the view that the view controller manages.
+    public override func loadView() {
+        let contentController = WKUserContentController()
+        contentController.add(self, name: "SurveyWindowInitialized")
+        contentController.add(self, name: "SurveyFinished")
+        
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = contentController
+        configuration.websiteDataStore = .nonPersistent()
+        configuration.allowsInlineMediaPlayback = true
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+        
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = self
+        webView.allowsBackForwardNavigationGestures = false
+        webView.allowsLinkPreview = false
+        webView.customUserAgent = userAgent
+        
+        view = webView
+    }
+    
+    /// Called after the view controller's view is loaded.
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        guard let webView = view as? WKWebView else { return }
+        guard case .uninitialized = viewState else { return }
+        
+        switch surveyURL {
+        case let .failure(error):
+            complete(.failure(error))
+        case let .success(url):
+            let request = URLRequest(url: url)
+            viewState = .loading(webView.load(request))
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(Self.timeoutIntervalSeconds)) { [weak self] in
+                self?.checkForLoadingTimeout()
+            }
+        }
+    }
+    
+    private func checkForLoadingTimeout() {
+        if case .loading = viewState {
+            complete(.failure(.webContentError(nil)))
+        }
+    }
+    
+    private func complete(_ result: Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) {
+        if case .completed = viewState { return }
+        completion(result)
+        viewState = .completed
+    }
+}
+
+/// Describes how a participant completed interaction with an embeddable survey.
+public struct EmbeddableSurveyCompletionReason: RawRepresentable, Equatable {
+    public typealias RawValue = String
+    
+    /// Participant completed the survey, and the result was saved to RKStudio.
+    public static let completed = EmbeddableSurveyCompletionReason(rawValue: "Completed")
+    /// Participant is dismissing the survey without completing it.
+    public static let closed = EmbeddableSurveyCompletionReason(rawValue: "Closed")
+    
+    /// The raw value for the completion reason.
+    public let rawValue: String
+    
+    /// Initializes a `EmbeddableSurveyCompletionReason` with an arbitrary value. Consider using static members such as `EmbeddableSurveyCompletionReason.completed` in equality checks or switch statements when inspecting completion reasons returned by embeddable surveys.
+    /// - Parameter rawValue: The raw value for the completion reason.
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+extension EmbeddableSurveyViewController: WKScriptMessageHandler {
+    /// Used internally within MyDataHelpsKit. Do not use this directly.
+    /// - Parameters:
+    ///   - userContentController: User content controller.
+    ///   - message: Message object from JavaScript.
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        switch (message.name, message.body) {
+        case ("SurveyWindowInitialized", _):
+            if case .loading = viewState {
+                viewState = .ready
+            }
+        case let ("SurveyFinished", info as [String: Any]):
+            if case .ready = viewState {
+                if let reasonValue = info["reason"] as? String {
+                    let completionReason = EmbeddableSurveyCompletionReason(rawValue: reasonValue)
+                    complete(.success(completionReason))
+                } else {
+                    // This happens for some specific failure scenarios, e.g. if the
+                    // survey name or task ID is invalid.
+                    complete(.failure(.webContentError(nil)))
+                }
+            }
+        default:
+            break
+        }
+    }
+}
+
+extension EmbeddableSurveyViewController: WKNavigationDelegate {
+    /// Used internally within MyDataHelpsKit. Do not use this directly.
+    /// - Parameters:
+    ///   - webView: The web view.
+    ///   - navigation: Navigation object.
+    ///   - error: Error associated with the failure.
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        if case .loading(navigation) = viewState {
+            complete(.failure(.webContentError(error)))
+        }
+    }
+    
+    /// Used internally within MyDataHelpsKit. Do not use this directly.
+    /// - Parameters:
+    ///   - webView: The web view.
+    ///   - navigation: Navigation object.
+    ///   - error: Error associated with the failure.
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        if case .loading(navigation) = viewState {
+            complete(.failure(.webContentError(error)))
+        }
+    }
+}
+
+internal extension MyDataHelpsClient {
+    func embeddableSurveyURL(taskLinkIdentifier: String, participantLinkIdentifier: String) -> Result<URL, MyDataHelpsError> {
+        do {
+            let url = try endpoint(path: "mydatahelps/\(participantLinkIdentifier)/tasklink/\(taskLinkIdentifier)", queryItems: [.init(name: "lang", value: languageTag)])
+            return .success(url)
+        } catch {
+            return .failure(.encodingError(error))
+        }
+    }
+    
+    func embeddableSurveyURL(surveyName: String, participantLinkIdentifier: String) -> Result<URL, MyDataHelpsError> {
+        do {
+            let url = try endpoint(path: "mydatahelps/\(participantLinkIdentifier)/surveylink/\(surveyName)", queryItems: [.init(name: "lang", value: languageTag)])
+            return .success(url)
+        } catch {
+            return .failure(.encodingError(error))
+        }
+    }
+}

--- a/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
+++ b/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
@@ -10,7 +10,7 @@ import WebKit
 
 /// Presents a MyDataHelps embeddable survey or task inside a web view. This view controller implements the complete user experience for a MyDataHelps survey, including step navigation, sending results to RKStudio, etc., and is intended for modal presentation.
 ///
-/// ## Enabling MyDataHelps embeddable surveys in RKStudio
+/// ### Enabling MyDataHelps embeddable surveys in RKStudio
 ///
 /// In order to use EmbeddableSurveyViewController to present a MyDataHelps embeddable survey, this feature must be enabled for both the project and the survey in RKStudio:
 /// - Enable "Allow Survey Completion Via Link" in project settings
@@ -18,13 +18,13 @@ import WebKit
 ///
 /// See [Completing Surveys with Survey Links](https://rkstudio-support.careevolution.com/hc/en-us/articles/360036515193-Completing-Surveys-with-Survey-Links) for more information.
 ///
-/// ## Initializing and presenting
+/// ### Initializing and presenting
 ///
 /// Create an EmbeddableSurveyViewController using one of its `init` methods, identifying the participant by their `participantLinkIdentifier` and the survey or task by `surveyName` or `taskLinkIdentifier`.
 ///
 /// For the best user experience, present this view controller modally, and do not wrap it in a UINavigationController, etc. The embedded survey content itself will display all of the controls necessary for navigation, such as localized Cancel/Done buttons.
 ///
-/// ## Completion and dismissal
+/// ### Completion and dismissal
 ///
 /// Once the participant has finished interacting with the survey, EmbeddableSurveyViewController will invoke the `completion` callback. The view controller will not dismiss itself. In all cases — success and failure — the completion callback _must_ dismiss the EmbeddableSurveyViewController.
 ///
@@ -85,13 +85,10 @@ public final class EmbeddableSurveyViewController: UIViewController {
         }
     }
     
-    /// Not implemented.
-    /// - Parameter coder: An unarchiver object.
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) is not implemented")
     }
     
-    /// Creates the view that the view controller manages.
     public override func loadView() {
         let contentController = WKUserContentController()
         contentController.add(self, name: "SurveyWindowInitialized")
@@ -112,7 +109,6 @@ public final class EmbeddableSurveyViewController: UIViewController {
         view = webView
     }
     
-    /// Called after the view controller's view is loaded.
     public override func viewDidLoad() {
         super.viewDidLoad()
         guard let webView = view as? WKWebView else { return }
@@ -166,10 +162,6 @@ public struct EmbeddableSurveyCompletionReason: RawRepresentable, Equatable {
 }
 
 extension EmbeddableSurveyViewController: WKScriptMessageHandler {
-    /// Used internally within MyDataHelpsKit. Do not use this directly.
-    /// - Parameters:
-    ///   - userContentController: User content controller.
-    ///   - message: Message object from JavaScript.
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         switch (message.name, message.body) {
         case ("SurveyWindowInitialized", _):
@@ -194,22 +186,12 @@ extension EmbeddableSurveyViewController: WKScriptMessageHandler {
 }
 
 extension EmbeddableSurveyViewController: WKNavigationDelegate {
-    /// Used internally within MyDataHelpsKit. Do not use this directly.
-    /// - Parameters:
-    ///   - webView: The web view.
-    ///   - navigation: Navigation object.
-    ///   - error: Error associated with the failure.
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         if case .loading(navigation) = viewState {
             complete(.failure(.webContentError(error)))
         }
     }
     
-    /// Used internally within MyDataHelpsKit. Do not use this directly.
-    /// - Parameters:
-    ///   - webView: The web view.
-    ///   - navigation: Navigation object.
-    ///   - error: Error associated with the failure.
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         if case .loading(navigation) = viewState {
             complete(.failure(.webContentError(error)))

--- a/MyDataHelpsKit/Model/MyDataHelpsError.swift
+++ b/MyDataHelpsKit/Model/MyDataHelpsError.swift
@@ -22,6 +22,8 @@ public enum MyDataHelpsError: Error {
     case timedOut(Error)
     /// An API request had a missing or invalid access token. The access token should be refreshed and a new `ParticipantSession` created, if applicable.
     case unauthorizedRequest(HTTPResponseError)
+    /// Web content (e.g. an embeddable survey) unexpectedly failed to load, due to a network, server, or web content failure. Includes any underlying error, if available.
+    case webContentError(Error?)
     /// A wrapper for unexpected errors. Includes the underlying Error object that triggered the unexpected error, if applicable.
     case unknown(Error?)
 }

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -74,7 +74,7 @@ public struct SurveyTaskResultPage: PagedResult, Decodable {
     public let nextPageID: String?
 }
 
-/// Describes the status of a survey task.
+/// Describes the status of a survey task assigned to a participant.
 public struct SurveyTaskStatus: RawRepresentable, Equatable, Hashable, Decodable {
     public typealias RawValue = String
     

--- a/MyDataHelpsKit/MyDataHelpsClient.swift
+++ b/MyDataHelpsKit/MyDataHelpsClient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Access to the MyDataHelps API endpoints. You can create a single instance of this for the lifetime of your app.
 ///
-/// `MyDataHelpsClient` instances do not track the authentication state or identity of a participant. Use `ParticipantSession` in conjuction with `MyDataHelps` client to perform authenticated actions.
+/// `MyDataHelpsClient` instances do not track the authentication state or identity of a participant. Use `ParticipantSession` in conjunction with `MyDataHelps` client to perform authenticated actions.
 public final class MyDataHelpsClient {
     /// Version number for this release of MyDataHelpsKit.
     public static let SDKVersion = MyDataHelpsKitVersion
@@ -21,7 +21,7 @@ public final class MyDataHelpsClient {
     internal let baseURL: URL
     internal let userAgent: String
     
-    /// Initializes a newly created client with the specifed configuration.
+    /// Initializes a newly created client with the specified configuration.
     /// - Parameter baseURL: Optional. If specified, overrides the base URL to use for MyDataHelps API requests. Production apps should not supply this parameter, and use the default base URL.
     public init(baseURL: URL? = nil) {
         self.baseURL = baseURL ?? Self.defaultBaseURL
@@ -33,6 +33,14 @@ public final class MyDataHelpsClient {
         configuration.timeoutIntervalForRequest = Self.requestTimeoutInterval
         configuration.urlCache = nil
         return URLSession(configuration: configuration, delegate: nil, delegateQueue: .main)
+    }
+    
+    internal var languageTag: String {
+        var acceptLanguage = Locale.current.languageCode ?? "en"
+        if let regionCode = Locale.current.regionCode {
+            acceptLanguage += "-\(regionCode)"
+        }
+        return acceptLanguage
     }
 }
 
@@ -46,7 +54,7 @@ fileprivate func userAgentString() -> String {
     } else {
         appVersionSuffix = ""
     }
-    let sdkInfo = "MyDataHelpsKit/\(MyDataHelpsClient.SDKVersion)"
+    let SDKInfo = "MyDataHelpsKit/\(MyDataHelpsClient.SDKVersion)"
     let deviceInfo = "\(getHardwareModelIdentifier() ?? "UNKNOWN_DEVICE") (\(getOSVersionString()))"
-    return "\(appIdentity)\(appVersionSuffix) \(sdkInfo) \(deviceInfo)"
+    return "\(appIdentity)\(appVersionSuffix) \(SDKInfo) \(deviceInfo)"
 }

--- a/MyDataHelpsKit/Session/ParticipantSession.swift
+++ b/MyDataHelpsKit/Session/ParticipantSession.swift
@@ -10,7 +10,9 @@ import Foundation
 /// Provides a context for performing authenticated actions on behalf of the participant.
 ///
 /// An instance of `ParticipantSession` should be retained for the lifetime of a participant's access token. Callers are responsible for tracking the state of an access token and renewing as needed.
+///
 /// ### Asynchronous behavior
+/// 
 /// Requests to the MyDataHelps platform are typically asynchronous. All asynchronous requests in ParticipantSession are implemented with a completion parameter of type `(Result<ModelType, MyDataHelpsError>) -> Void`, where `ModelType` is the type of the data model object returned upon success. All completion blocks are invoked on the main thread.
 public final class ParticipantSession {
     
@@ -19,7 +21,7 @@ public final class ParticipantSession {
     internal let session: URLSession
     
     /// Initializes a new session using an access token.
-    /// - Parameter client: The MyDataHelps client to use with this session.
+    /// - Parameter client: The client to use for all API access by this session.
     /// - Parameter accessToken: An authentication token. Must be valid and not expired, or all actions performed with this session will fail with authorization failures.
     public init(client: MyDataHelpsClient, accessToken: ParticipantAccessToken) {
         self.client = client

--- a/MyDataHelpsKitTests/MyDataHelpsClientTests.swift
+++ b/MyDataHelpsKitTests/MyDataHelpsClientTests.swift
@@ -11,28 +11,38 @@ import XCTest
 class MyDataHelpsClientTests: XCTestCase {
     func testDefaultBaseURL() {
         let sut = MyDataHelpsClient()
-        // Detect accidental base URL changes
-        XCTAssertEqual(sut.baseURL.absoluteString, "https://rkstudio.careevolution.com/ppt/")
+        XCTAssertEqual(sut.baseURL.absoluteString, "https://rkstudio.careevolution.com/ppt/", "Default client uses correct base URL")
     }
     
     func testEndpoint() {
-        let sut = MyDataHelpsClient()
-        let url = sut.endpoint(path: "example")
-        // Detect accidental base URL changes
-        XCTAssertEqual(url.absoluteString, "https://rkstudio.careevolution.com/ppt/example")
+        var sut = MyDataHelpsClient()
+        var url = sut.endpoint(path: "example/path/1")
+        XCTAssertEqual(url.absoluteString, "https://rkstudio.careevolution.com/ppt/example/path/1", "Default client uses correct base URL in endpoint URLs")
+        
+        sut = MyDataHelpsClient(baseURL: URL(string: "https://example.com/api/")!)
+        url = sut.endpoint(path: "example/path/2")
+        XCTAssertEqual(sut.baseURL.absoluteString, "https://example.com/api/", "Custom base URL")
+        XCTAssertEqual(url.absoluteString, "https://example.com/api/example/path/2", "Endpoint with custom base URL")
     }
     
     func testEndpointWithQueryItems() {
         let sut = MyDataHelpsClient()
         var url = try? sut.endpoint(path: "example", queryItems: [])
-        XCTAssertNotNil(url)
-        if let urlString = url?.absoluteString {
-            XCTAssertEqual(urlString, "https://rkstudio.careevolution.com/ppt/example?")
-        }
+        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/example?")
         
         url = try? sut.endpoint(path: "example/path", queryItems: [.init(name: "a", value: "b")])
-        if let urlString = url?.absoluteString {
-            XCTAssertEqual(urlString, "https://rkstudio.careevolution.com/ppt/example/path?a=b")
-        }
+        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/example/path?a=b")
+    }
+    
+    func testEmbeddableURLs() {
+        let sut = MyDataHelpsClient()
+        let participantLinkID = UUID().uuidString
+        let surveyName = UUID().uuidString
+        let taskLinkID = UUID().uuidString
+        let languageTag = sut.languageTag
+        var url = try? sut.embeddableSurveyURL(surveyName: surveyName, participantLinkIdentifier: participantLinkID).get()
+        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/mydatahelps/\(participantLinkID)/surveylink/\(surveyName)?lang=\(languageTag)")
+        url = try? sut.embeddableSurveyURL(taskLinkIdentifier: taskLinkID, participantLinkIdentifier: participantLinkID).get()
+        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/mydatahelps/\(participantLinkID)/tasklink/\(taskLinkID)?lang=\(languageTag)")
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An SDK to integrate RKStudio™ with your apps to develop your own participant experiences.
 
+See [GitHub releases](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases) for release notes.
+
 [© CareEvolution, LLC](https://developer.rkstudio.careevolution.com)
 
 ## Getting started

--- a/example/MyDataHelpsKit-Example.xcodeproj/project.pbxproj
+++ b/example/MyDataHelpsKit-Example.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		AC44F53E261375EE0065075C /* MyDataHelpsKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC44F53D261375EE0065075C /* MyDataHelpsKit.framework */; };
 		AC44F53F261375EE0065075C /* MyDataHelpsKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC44F53D261375EE0065075C /* MyDataHelpsKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AC44F561261610A10065075C /* PersistDeviceDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC44F560261610A10065075C /* PersistDeviceDataView.swift */; };
+		AC8E0BB626694D830072A9C1 /* EmbeddableSurveySelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E0BB526694D830072A9C1 /* EmbeddableSurveySelection.swift */; };
+		AC932355265D9AEB007AAF69 /* EmbeddableSurveyViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC932354265D9AEB007AAF69 /* EmbeddableSurveyViewRepresentable.swift */; };
 		AC9DC9E2260E374E00C5D9E4 /* MyDataHelpsKit_ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9DC9E1260E374E00C5D9E4 /* MyDataHelpsKit_ExampleApp.swift */; };
 		AC9DC9E4260E374E00C5D9E4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9DC9E3260E374E00C5D9E4 /* ContentView.swift */; };
 		AC9DC9E6260E374F00C5D9E4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC9DC9E5260E374F00C5D9E4 /* Assets.xcassets */; };
@@ -51,6 +53,8 @@
 		AC44F53D261375EE0065075C /* MyDataHelpsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MyDataHelpsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC44F54126137CBE0065075C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		AC44F560261610A10065075C /* PersistDeviceDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistDeviceDataView.swift; sourceTree = "<group>"; };
+		AC8E0BB526694D830072A9C1 /* EmbeddableSurveySelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddableSurveySelection.swift; sourceTree = "<group>"; };
+		AC932354265D9AEB007AAF69 /* EmbeddableSurveyViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddableSurveyViewRepresentable.swift; sourceTree = "<group>"; };
 		AC9DC9DE260E374E00C5D9E4 /* MyDataHelpsKit-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MyDataHelpsKit-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC9DC9E1260E374E00C5D9E4 /* MyDataHelpsKit_ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDataHelpsKit_ExampleApp.swift; sourceTree = "<group>"; };
 		AC9DC9E3260E374E00C5D9E4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -96,6 +100,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		AC932353265D9A7F007AAF69 /* Embeddables */ = {
+			isa = PBXGroup;
+			children = (
+				AC8E0BB526694D830072A9C1 /* EmbeddableSurveySelection.swift */,
+				AC932354265D9AEB007AAF69 /* EmbeddableSurveyViewRepresentable.swift */,
+			);
+			path = Embeddables;
+			sourceTree = "<group>";
+		};
 		AC9DC9D5260E374E00C5D9E4 = {
 			isa = PBXGroup;
 			children = (
@@ -119,6 +132,7 @@
 			children = (
 				AC9DC9E5260E374F00C5D9E4 /* Assets.xcassets */,
 				AC9DC9E3260E374E00C5D9E4 /* ContentView.swift */,
+				AC932353265D9A7F007AAF69 /* Embeddables */,
 				AC9DCA13260E3E5700C5D9E4 /* ErrorView.swift */,
 				AC9DC9EA260E374F00C5D9E4 /* Info.plist */,
 				AC9DCA09260E3BBA00C5D9E4 /* LoadingView.swift */,
@@ -142,11 +156,11 @@
 		AC9DC9F5260E37B500C5D9E4 /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				AC9DCA06260E3BAC00C5D9E4 /* ParticipantInfoView.swift */,
+				AC9DCA0C260E3CE700C5D9E4 /* ParticipantModel.swift */,
 				AC9DCA02260E3A7D00C5D9E4 /* RootMenuView.swift */,
 				AC9DC9FA260E39AF00C5D9E4 /* SessionModel.swift */,
 				AC9DC9F6260E37C700C5D9E4 /* TokenView.swift */,
-				AC9DCA06260E3BAC00C5D9E4 /* ParticipantInfoView.swift */,
-				AC9DCA0C260E3CE700C5D9E4 /* ParticipantModel.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -156,14 +170,14 @@
 			children = (
 				ACCD97EC260E58AF00FF7438 /* DeviceDataPointView.swift */,
 				ACCD97E9260E4DFE00FF7438 /* DeviceDataSource.swift */,
+				ACCD9803260E6F7A00FF7438 /* NotificationHistorySource.swift */,
+				ACCD9800260E6E3000FF7438 /* NotificationHistoryView.swift */,
 				ACCD97E5260E492100FF7438 /* PagedView.swift */,
 				ACCD97EF260E5A8600FF7438 /* PagedViewModel.swift */,
+				ACCD97FD260E667E00FF7438 /* SurveyAnswersSource.swift */,
+				ACCD97F8260E5F3000FF7438 /* SurveyAnswerView.swift */,
 				ACCD97F5260E5D0100FF7438 /* SurveyTaskSource.swift */,
 				ACCD97F2260E5AE300FF7438 /* SurveyTaskView.swift */,
-				ACCD97F8260E5F3000FF7438 /* SurveyAnswerView.swift */,
-				ACCD97FD260E667E00FF7438 /* SurveyAnswersSource.swift */,
-				ACCD9800260E6E3000FF7438 /* NotificationHistoryView.swift */,
-				ACCD9803260E6F7A00FF7438 /* NotificationHistorySource.swift */,
 			);
 			path = PagedView;
 			sourceTree = "<group>";
@@ -242,6 +256,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AC932355265D9AEB007AAF69 /* EmbeddableSurveyViewRepresentable.swift in Sources */,
 				ACCD97F0260E5A8600FF7438 /* PagedViewModel.swift in Sources */,
 				AC9DCA07260E3BAC00C5D9E4 /* ParticipantInfoView.swift in Sources */,
 				ACCD9801260E6E3000FF7438 /* NotificationHistoryView.swift in Sources */,
@@ -256,6 +271,7 @@
 				AC9DCA03260E3A7D00C5D9E4 /* RootMenuView.swift in Sources */,
 				ACCD97EA260E4DFE00FF7438 /* DeviceDataSource.swift in Sources */,
 				ACCD97F9260E5F3000FF7438 /* SurveyAnswerView.swift in Sources */,
+				AC8E0BB626694D830072A9C1 /* EmbeddableSurveySelection.swift in Sources */,
 				AC9DCA0A260E3BBA00C5D9E4 /* LoadingView.swift in Sources */,
 				AC9DCA14260E3E5700C5D9E4 /* ErrorView.swift in Sources */,
 				ACCD97F3260E5AE300FF7438 /* SurveyTaskView.swift in Sources */,

--- a/example/MyDataHelpsKit-Example.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit-Example.xcscheme
+++ b/example/MyDataHelpsKit-Example.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/MyDataHelpsKit-Example/ContentView.swift
+++ b/example/MyDataHelpsKit-Example/ContentView.swift
@@ -16,10 +16,13 @@ struct ContentView: View {
             if let session = sessionModel.session {
                 RootMenuView(participant: .init(session: session))
                     .navigationTitle(title)
+                    .navigationBarTitleDisplayMode(.inline)
                     .navigationBarItems(trailing: Button("Log Out", action: logOut))
             } else {
                 TokenView()
                     .navigationTitle(title)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .navigationBarItems(trailing: EmptyView())
             }
         }
     }

--- a/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveySelection.swift
+++ b/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveySelection.swift
@@ -1,0 +1,34 @@
+//
+//  EmbeddableSurveySelection.swift
+//  MyDataHelpsKit-Example
+//
+//  Created by CareEvolution on 6/3/21.
+//
+
+import Foundation
+import MyDataHelpsKit
+
+struct EmbeddableSurveySelection: Identifiable {
+    let survey: EmbeddableSurveyID
+    let participantLinkIdentifier: String
+    
+    var id: String {
+        switch survey {
+        case let .surveyName(name): return name
+        case let .taskLinkIdentifier(name): return name
+        }
+    }
+}
+
+enum EmbeddableSurveyID: Identifiable {
+    case surveyName(String)
+    case taskLinkIdentifier(String)
+    
+    var id: String {
+        switch self {
+        case let .surveyName(name): return name
+        case let .taskLinkIdentifier(name): return name
+        }
+    }
+}
+

--- a/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveyViewRepresentable.swift
+++ b/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveyViewRepresentable.swift
@@ -1,0 +1,67 @@
+//
+//  EmbeddableSurveyViewRepresentable.swift
+//  MyDataHelpsKit-Example
+//
+//  Created by CareEvolution on 5/25/21.
+//
+
+import SwiftUI
+import MyDataHelpsKit
+
+// SwiftUI wrapper for MyDataHelpsKit.EmbeddableSurveyViewController
+struct EmbeddableSurveyViewRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = UIViewController
+    
+    @EnvironmentObject private var sessionModel: SessionModel
+    let model: EmbeddableSurveySelection
+    var presentation: Binding<EmbeddableSurveySelection?>
+    var error: Binding<MyDataHelpsError?>
+    
+    func makeUIViewController(context: Context) -> UIViewController {
+        return makeSurveyViewController()
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+    
+    private func makeSurveyViewController() -> UIViewController {
+        let completion: (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void = {
+            if case let .failure(errorResult) = $0 {
+                error.wrappedValue = errorResult
+            } else {
+                error.wrappedValue = nil
+            }
+            presentation.wrappedValue = nil
+        }
+        switch model.survey {
+        case let .surveyName(surveyName):
+            return EmbeddableSurveyViewController(client: sessionModel.client, surveyName: surveyName, participantLinkIdentifier: model.participantLinkIdentifier, completion: completion)
+        case let .taskLinkIdentifier(taskLinkIdentifier):
+            return EmbeddableSurveyViewController(client: sessionModel.client, taskLinkIdentifier: taskLinkIdentifier, participantLinkIdentifier: model.participantLinkIdentifier, completion: completion)
+        }
+    }
+}
+
+struct EmbeddableSurveyViewRepresentable_Previews: PreviewProvider {
+    private struct ContainerView: View {
+        @State var selection: EmbeddableSurveySelection? = nil
+        @State var surveyError: MyDataHelpsError? = nil {
+            didSet {
+                errorModel = surveyError.map { .init(title: "Error", error: $0) }
+            }
+        }
+        @State var errorModel: ErrorView.Model? = nil
+        
+        var body: some View {
+            EmbeddableSurveyViewRepresentable(model: .init(survey: .surveyName(""), participantLinkIdentifier: ""), presentation: $selection, error: $surveyError)
+                .alert(item: $errorModel) {
+                    Alert(title: Text($0.errorDescription))
+                }
+        }
+    }
+    
+    static var previews: some View {
+        ContainerView()
+            .environmentObject(SessionModel())
+    }
+}

--- a/example/MyDataHelpsKit-Example/ErrorView.swift
+++ b/example/MyDataHelpsKit-Example/ErrorView.swift
@@ -9,17 +9,45 @@ import SwiftUI
 import MyDataHelpsKit
 
 struct ErrorView: View {
-    let title: String
-    let error: MyDataHelpsError
+    struct Model: Identifiable {
+        let id = UUID().uuidString
+        let title: String
+        let error: MyDataHelpsError
+        
+        var errorDescription: String {
+            switch error {
+            case let .decodingError(underlying):
+                return "Decoding error: \(underlying.localizedDescription)"
+            case let .encodingError(underlying):
+                return "Encoding error: \(underlying.localizedDescription)"
+            case let .serverError(underlying):
+                return "Server error: \(underlying.localizedDescription)"
+            case let .timedOut(underlying):
+                return "Timed out: \(underlying.localizedDescription)"
+            case let .unauthorizedRequest(underlying):
+                return "Unauthorized: \(underlying.localizedDescription)"
+            case let .unknown(.some(underlying)):
+                return "Unknown error: \(underlying.localizedDescription)"
+            case .unknown(.none):
+                return "Unknown error"
+            case let .webContentError(.some(underlying)):
+                return "Web content error: \(underlying.localizedDescription)"
+            case .webContentError(.none):
+                return "Web content error"
+            }
+        }
+    }
+    
+    let model: Model
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text(title)
+            Text(model.title)
                 .font(.subheadline)
                 .fontWeight(.semibold)
                 .foregroundColor(Color.red)
                 
-            Text(error.localizedDescription)
+            Text(model.errorDescription)
                 .font(.caption)
                 .foregroundColor(Color.red)
         }
@@ -28,7 +56,7 @@ struct ErrorView: View {
 
 struct ErrorView_Previews: PreviewProvider {
     static var previews: some View {
-        ErrorView(title: "Error Doing X", error: .unknown(nil))
+        ErrorView(model: .init(title: "Error Doing X", error: .unknown(nil)))
             .padding()
     }
 }

--- a/example/MyDataHelpsKit-Example/PagedView/PagedView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/PagedView.swift
@@ -19,7 +19,7 @@ struct PagedView<SourceType, ViewType>: View where SourceType: PagedModelSource,
                 .fontWeight(.semibold)
                 .padding()
         case let .failure(error):
-            ErrorView(title: "Failed to load", error: error)
+            ErrorView(model: .init(title: "Failed to load", error: error))
         case let .normal(loadMore):
             List {
                 Section {

--- a/example/MyDataHelpsKit-Example/PagedView/SurveyTaskSource.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/SurveyTaskSource.swift
@@ -8,7 +8,7 @@
 import Foundation
 import MyDataHelpsKit
 
-class SurveyTaskSource: PagedModelSource {
+class SurveyTaskSource: PagedModelSource, ObservableObject {
     let session: ParticipantSessionType
     private let query: SurveyTaskQuery
     

--- a/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
@@ -10,6 +10,7 @@ import MyDataHelpsKit
 
 struct ParticipantInfoViewModel {
     let name: String
+    let linkIdentifier: String?
     let email: String?
     let phone: String?
 }
@@ -19,6 +20,7 @@ extension ParticipantInfoViewModel {
         var tokens = [info.demographics.firstName, info.demographics.lastName]
         if tokens.isEmpty { tokens = ["(no name)"] }
         self.name = tokens.compactMap { $0 }.joined(separator: " ")
+        self.linkIdentifier = info.linkIdentifier
         self.email = info.demographics.email
         self.phone = info.demographics.mobilePhone
     }
@@ -47,6 +49,7 @@ struct ParticipantInfoView_Previews: PreviewProvider {
         ParticipantInfoView(
             model: .init(
                 name: "Firstname Lastname",
+                linkIdentifier: nil,
                 email: nil,
                 phone: "555-555-1212"))
     }

--- a/example/MyDataHelpsKit-Example/Session/ParticipantModel.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantModel.swift
@@ -30,7 +30,7 @@ extension ParticipantSession: ParticipantSessionType {
 
 class ParticipantSessionPreview: ParticipantSessionType {
     func getParticipantInfoViewModel(completion: @escaping (Result<ParticipantInfoViewModel, MyDataHelpsError>) -> Void) {
-        completion(.success(.init(name: "name", email: "email", phone: "phone")))
+        completion(.success(.init(name: "name", linkIdentifier: nil, email: "email", phone: "phone")))
     }
     
     func queryDeviceData(_ query: DeviceDataQuery, completion: @escaping (Result<DeviceDataResultPage, MyDataHelpsError>) -> Void) {

--- a/example/MyDataHelpsKit-Example/Session/SessionModel.swift
+++ b/example/MyDataHelpsKit-Example/Session/SessionModel.swift
@@ -9,11 +9,15 @@ import Foundation
 import MyDataHelpsKit
 
 class SessionModel: ObservableObject {
+    let client: MyDataHelpsClient
     @Published var token: String = ""
     @Published var session: ParticipantSession? = nil
     
+    init() {
+         self.client = MyDataHelpsClient()
+    }
+    
     func authenticate() {
-        let client = MyDataHelpsClient()
         session = ParticipantSession(client: client, accessToken: .init(token: token))
     }
     

--- a/example/README.md
+++ b/example/README.md
@@ -21,14 +21,13 @@ The headings below describe the functionality you can find in each subview acces
 
 - Demonstrates usage of `ParticipantSession.querySurveyTasks`. Modify the `SurveyTaskView.pageView` function to experiment with different query parameters
 - Demonstrates `ParticipantSession.querySurveyAnswers`, by tapping on completed surveys
-- Demonstrates embeddable survey functionality, by tapping on incomplete surveys. To use this feature, embeddable survey functionality must be enabled in RKStudio for the project and the survey
 
 ### Query Survey Answers
 
 - Demonstrates general usage of `ParticipantSession.querySurveyAnswers`. Modify the `SurveyAnswerView.pageView` function to experiment with different query parameters
 - Demonstrates deleting specific survey results, if deletion is enabled for the survey in RKStudio
 
-### Device data
+### Device Data
 
 - **Device Data: Apple Health** and **Device Data: Project** demonstrates using `ParticipantSession.queryDeviceData` to query and list device data under the Apple Health or Project namespaces. Modify `RootMenuView` and the `DeviceDataPointView.pageView` function to experiment with different query parameters
 - **Persist New Device Data** demonstrates creating and saving new device data in the Project namespace
@@ -36,3 +35,7 @@ The headings below describe the functionality you can find in each subview acces
 ### Query Notifications
 
 - Demonstrates usage of `b`. Modify the `NotificationHistoryView.pageView` function to experiment with different query parameters
+
+### MyDataHelps Embeddable Surveys
+
+To see examples of using `EmbeddableSurveyViewController` to present MyDataHelps embeddable surveys, tap on incomplete surveys in the Survey Tasks screen. To use this feature, embeddable survey functionality must be enabled in RKStudio for the project and the survey. See EmbeddableSurveyViewController's documentation for more info on usage and links to relevant RKStudio documentation.

--- a/example/README.md
+++ b/example/README.md
@@ -3,3 +3,36 @@
 A SwiftUI app demonstrating usage of MyDataHelpsKit. For more information about the MyDataHelpsKit SDK, see the main [readme file](https://github.com/CareEvolution/MyDataHelpsKit-iOS).
 
 To get started, open `MyDataHelpsKit-Example.xcworkspace` in Xcode and run the app. Once the app launches, you will need to enter a valid participant token to authenticate and use the app's functionality. See [documentation on Participant Tokens](https://developer.rkstudio.careevolution.com/sdk/participant_tokens.html) for more information about obtaining an access token.
+
+Once you enter a participant token, the example app initializes a `ParticipantSession` and displays the RootMenuView, from which you can navigate to various other views to demonstrate each of the MyDataHelpsKit APIs.
+
+There are several ParticipantSession APIs that take query objects and produce paged arrays of results. These are all implemented in the example app with a generic `PagedView` SwiftUI view, and appropriate data source objects that perform the actual queries against ParticipantSession and construct individual SwiftUI views for each item in the results.
+
+## Example app features
+
+The headings below describe the functionality you can find in each subview accessed from the example app's main menu (`RootMenuView`):
+
+### Participant Info
+
+- After entering a valid participant token and proceeding to the main menu, the app immediately loads and displays the ParticipantInfo object via `ParticipantSession.getParticipantInfo`
+- Modify `ParticipantInfoView` to experiment with displaying various ParticipantInfo properties or demographic fields
+
+### Query Survey Tasks
+
+- Demonstrates usage of `ParticipantSession.querySurveyTasks`. Modify the `SurveyTaskView.pageView` function to experiment with different query parameters
+- Demonstrates `ParticipantSession.querySurveyAnswers`, by tapping on completed surveys
+- Demonstrates embeddable survey functionality, by tapping on incomplete surveys. To use this feature, embeddable survey functionality must be enabled in RKStudio for the project and the survey
+
+### Query Survey Answers
+
+- Demonstrates general usage of `ParticipantSession.querySurveyAnswers`. Modify the `SurveyAnswerView.pageView` function to experiment with different query parameters
+- Demonstrates deleting specific survey results, if deletion is enabled for the survey in RKStudio
+
+### Device data
+
+- **Device Data: Apple Health** and **Device Data: Project** demonstrates using `ParticipantSession.queryDeviceData` to query and list device data under the Apple Health or Project namespaces. Modify `RootMenuView` and the `DeviceDataPointView.pageView` function to experiment with different query parameters
+- **Persist New Device Data** demonstrates creating and saving new device data in the Project namespace
+
+### Query Notifications
+
+- Demonstrates usage of `b`. Modify the `NotificationHistoryView.pageView` function to experiment with different query parameters


### PR DESCRIPTION
## Overview

Closes #2 

Depends on https://github.com/CareEvolution/Consumers/pull/9871

- `EmbeddableSurveyViewController` implements embedded surveys via a WKWebView. Includes extensive documentation: I'd appreciate a review of the documentation comments found throughout that class
- Significant expansion to the example app's readme
- Minor documentation fixes (e.g. spelling errors)

### Implementation notes

EmbeddableSurveyViewController performs the following steps in order, tracked by a `state` var:

1. During init, constructs the URL to load using the participant link identifier, plus a survey name or task link identifier
2. During loadView and viewDidLoad, initializes a WKWebView and begins loading the URL
3. The survey is expected to post a WebKit JavaScript message "SurveyWindowInitialized". The view controller uses this, rather than just checking whether the HTTP request succeeded, to know that the survey successfully loaded
4. When the user completes or decides to cancel the survey, the survey posts a "SurveyFinished" message to EmbeddableSurveyViewController. The view controller then invokes the completion callback with `.success`
5. If the web view fails to load, or if "SurveyWindowInitialized" is not received after a timeout period, EmbeddableSurveyViewController invokes the completion callback with `.failure`

## Checklist

- [x] All public symbols are documented using Appledoc comments
- [x] Source code file header comments are clean and standardized. Don't leak an individual developer's identity. e.g. "Created by CareEvolution on m/dd/yy"
- [x] No temporary debugging code committed (e.g. API base URL, print/NSLog statements, etc.)
- [x] Xcode project/target settings are generic. Don't leak any team identifiers, code signing info, local filesystem paths, etc.
- [x] Test and update the example app as needed
- [x] Request security review, if applicable, or describe why no review is required

## Security

This adds a new web view that displays the contents of a URL.

The web view URL is constructed by appending some caller-supplied strings to a base URL (which defaults to the MyDataHelps production server) (see the bottom of `EmbeddableSurveyViewController.swift`). The SDK client is responsible for supplying valid values to ensure the correct URL is loaded, but I believe there should be no risk of invoking sensitive URLs in our server environment, just invalid/missing surveys/participant identifiers. Note the participant/survey IDs used in the URL are separate identifiers generated specifically for this sort of public use.

The web view receives and interprets runtime messages from that URL via the WebKit JavaScript bridge (see the `extension EmbeddableSurveyViewController: WKScriptMessageHandler` declaration in `EmbeddableSurveyViewController.swift`). It only checks for some predetermined strings in the JavaScript message; it does not expose arbitrary data to the SDK client and should be robust to various unexpected data or failure scenarios.

The web view uses a `nonPersistent` data store, so all web content data is stored in memory, not written to disk. The web content is not accessible to the SDK client or even (except for the JavaScript callbacks mentioned above) the SDK itself.

## Testing

EmbeddableSurveyViewController is accessed in the example app via Query Survey Tasks > select an incomplete task. The project and task must have "allow completion via link" enabled in RKStudio.

https://user-images.githubusercontent.com/2637734/124191076-3a68ec80-da91-11eb-886b-b96dd5607f1b.mov

