### PR TITLE
Set up CI via GitHub Actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v

--- a/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
+++ b/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
@@ -5,6 +5,10 @@
 //  Created by CareEvolution on 5/25/21.
 //
 
+import Foundation
+
+#if canImport(UIKit)
+
 import UIKit
 import WebKit
 
@@ -198,6 +202,8 @@ extension EmbeddableSurveyViewController: WKNavigationDelegate {
         }
     }
 }
+
+#endif
 
 internal extension MyDataHelpsClient {
     func embeddableSurveyURL(taskLinkIdentifier: String, participantLinkIdentifier: String) -> Result<URL, MyDataHelpsError> {

--- a/MyDataHelpsKitTests/URLRequestsTests.swift
+++ b/MyDataHelpsKitTests/URLRequestsTests.swift
@@ -53,7 +53,8 @@ class URLRequestsTests: XCTestCase {
     func testDateQueryStringEncoding() {
         let date = DateComponents(calendar: .current, timeZone: .current, year: 2021, month: 2, day: 17, hour: 9, minute: 41, second: 0, nanosecond: 123000000).date!
         let offsetFormatter = DateFormatter()
-        offsetFormatter.dateFormat = "Z" // e.g. "-0600"
+        // e.g. "-0600" or "Z". Matches ISO8601DateFormatter's behavior
+        offsetFormatter.dateFormat = "XX"
         XCTAssertEqual(date.queryStringEncoded, "2021-02-17T09:41:00.123\(offsetFormatter.string(from: date))")
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
         .testTarget(
             name: "MyDataHelpsKitTests",
             dependencies: ["MyDataHelpsKit"],
-            path: "MyDataHelpsKitTests"
+            path: "MyDataHelpsKitTests",
+            exclude: ["Info.plist"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To update MyDataHelpsKit to a newer version, run `pod update`, optionally append
 
 ### Manual integration
 
-1. Download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases)
+1. Download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases) from GitHub
 2. From Finder, drag `MyDataHelpsKit.xcodeproj`  into your app's Xcode workspace
 3. Open your app target's General settings tab in Xcode. In the project navigator pane, expand MyDataHelpsKit.xcodeproj > Products and drag MyDataHelpsKit.framework into the "Frameworks, Libraries, and Embedded Content" section 
 


### PR DESCRIPTION
Closes #4

Uses `swift build` and `swift test` to run unit tests.

Looks like it takes some effort to set up Package.swift correctly to avoid errors caused by `import UIKit` when running `swift test` from the command line. The simplest solution was to just wrap our only UIKit dependency (which doesn't have anything to unit test) with `#if canImport(UIKit)`.

I tested that projects that use MyDataHelpsKit as a Swift Package Manager dependency can still successfully import the latest commits, and use EmbeddableSurveyViewController, so I'm comfortable with the canImport solution unless we have need to unit test UIKit code.

## Security

No concerns here: uses the standard "Swift" GitHub Action, published by GitHub itself, and the action uses only the built-in Apple utility `swift`, in a standard macOS environment. There are no secret keys or other environment settings necessary.