### PR TITLE
Rate limit errors and various query/model additions

### DIFF
--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		AC9DC9C0260A876F00C5D9E4 /* MyDataHelpsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9DC9BF260A876F00C5D9E4 /* MyDataHelpsClientTests.swift */; };
 		ACA1A86726D5413A00CBD7EA /* ExternalAccountProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA1A86626D5413A00CBD7EA /* ExternalAccountProviders.swift */; };
 		ACA1A86926D5442800CBD7EA /* ExternalAccountProvidersQueryResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA1A86826D5442800CBD7EA /* ExternalAccountProvidersQueryResource.swift */; };
+		ACBF66C427CFD37200BC6945 /* APIRateLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBF66C327CFD37200BC6945 /* APIRateLimit.swift */; };
+		ACBF66C627CFE18800BC6945 /* APIRateLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBF66C527CFE18800BC6945 /* APIRateLimitTests.swift */; };
 		ACC2EB9B261252F50080A3B5 /* SDKVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC2EB9A261252F50080A3B5 /* SDKVersion.swift */; };
 		ACEAF44C26D67CE0002F79AB /* ExternalAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEAF44B26D67CE0002F79AB /* ExternalAccounts.swift */; };
 		ACEAF44E26D683F7002F79AB /* ExternalAccountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEAF44D26D683F7002F79AB /* ExternalAccountsTests.swift */; };
@@ -85,6 +87,8 @@
 		AC9DC9BF260A876F00C5D9E4 /* MyDataHelpsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDataHelpsClientTests.swift; sourceTree = "<group>"; };
 		ACA1A86626D5413A00CBD7EA /* ExternalAccountProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAccountProviders.swift; sourceTree = "<group>"; };
 		ACA1A86826D5442800CBD7EA /* ExternalAccountProvidersQueryResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAccountProvidersQueryResource.swift; sourceTree = "<group>"; };
+		ACBF66C327CFD37200BC6945 /* APIRateLimit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRateLimit.swift; sourceTree = "<group>"; };
+		ACBF66C527CFE18800BC6945 /* APIRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRateLimitTests.swift; sourceTree = "<group>"; };
 		ACC2EB9A261252F50080A3B5 /* SDKVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKVersion.swift; sourceTree = "<group>"; };
 		ACEAF44B26D67CE0002F79AB /* ExternalAccounts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAccounts.swift; sourceTree = "<group>"; };
 		ACEAF44D26D683F7002F79AB /* ExternalAccountsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAccountsTests.swift; sourceTree = "<group>"; };
@@ -150,6 +154,7 @@
 		AC77B50625E852EE00427294 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				ACBF66C327CFD37200BC6945 /* APIRateLimit.swift */,
 				AC83ABB525E864DC00A668E4 /* DeviceData.swift */,
 				AC77B50F25E856D000427294 /* MyDataHelpsError.swift */,
 				AC9DC9B52609064800C5D9E4 /* NotificationHistory.swift */,
@@ -192,6 +197,7 @@
 		AC83ABDA25F131DA00A668E4 /* MyDataHelpsKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				ACBF66C527CFE18800BC6945 /* APIRateLimitTests.swift */,
 				ACEAF44D26D683F7002F79AB /* ExternalAccountsTests.swift */,
 				AC83ABDD25F131DA00A668E4 /* Info.plist */,
 				AC9DC9BF260A876F00C5D9E4 /* MyDataHelpsClientTests.swift */,
@@ -366,6 +372,7 @@
 				AC83ABB125E85BB900A668E4 /* GetParticipantInfoResource.swift in Sources */,
 				AC77B50925E8535B00427294 /* ParticipantAccessToken.swift in Sources */,
 				AC83ABBD25E885D700A668E4 /* PersistDeviceDataResource.swift in Sources */,
+				ACBF66C427CFD37200BC6945 /* APIRateLimit.swift in Sources */,
 				AC77B51525E8576A00427294 /* ParticipantResource.swift in Sources */,
 				27AA30DB26D68ECB00AC0D2C /* ExternalAccountsResource.swift in Sources */,
 				ACEAF44C26D67CE0002F79AB /* ExternalAccounts.swift in Sources */,
@@ -384,6 +391,7 @@
 			files = (
 				AC83ABDC25F131DA00A668E4 /* URLRequestsTests.swift in Sources */,
 				AC9DC9C0260A876F00C5D9E4 /* MyDataHelpsClientTests.swift in Sources */,
+				ACBF66C627CFE18800BC6945 /* APIRateLimitTests.swift in Sources */,
 				ACEAF44E26D683F7002F79AB /* ExternalAccountsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -281,7 +281,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1320;
 				TargetAttributes = {
 					AC77B4B825E8495C00427294 = {
 						CreatedOnToolsVersion = 12.4;

--- a/MyDataHelpsKit.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit.xcscheme
+++ b/MyDataHelpsKit.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MyDataHelpsKit/API/DeviceDataQueryResource.swift
+++ b/MyDataHelpsKit/API/DeviceDataQueryResource.swift
@@ -24,6 +24,12 @@ struct DeviceDataQueryResource: ParticipantResource {
         if let observedBefore = query.observedBefore?.queryStringEncoded {
             queryItems.append(.init(name: "observedBefore", value: observedBefore))
         }
+        if let modifiedAfter = query.modifiedAfter?.queryStringEncoded {
+            queryItems.append(.init(name: "modifiedAfter", value: modifiedAfter))
+        }
+        if let modifiedBefore = query.modifiedBefore?.queryStringEncoded {
+            queryItems.append(.init(name: "modifiedBefore", value: modifiedBefore))
+        }
         
         queryItems.append(.init(name: "limit", value: "\(query.limit)"))
         if let pageID = query.pageID {

--- a/MyDataHelpsKit/API/ParticipantResource.swift
+++ b/MyDataHelpsKit/API/ParticipantResource.swift
@@ -52,7 +52,11 @@ extension ParticipantSession {
         }
         guard response.statusCode >= 200, response.statusCode < 300 else {
             let responseError = HTTPResponseError(response: response, data: data, error: error)
-            if response.statusCode == 401 {
+            
+            if response.statusCode == 429,
+               let limit = APIRateLimit(response: response) {
+                return .failure(.tooManyRequests(limit, responseError))
+            } else if response.statusCode == 401 {
                 return .failure(.unauthorizedRequest(responseError))
             } else {
                 return .failure(.serverError(responseError))

--- a/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
@@ -29,6 +29,12 @@ struct SurveyAnswersQueryResource: ParticipantResource {
         if let before = query.before?.queryStringEncoded {
             queryItems.append(.init(name: "before", value: before))
         }
+        if let insertedAfter = query.insertedAfter?.queryStringEncoded {
+            queryItems.append(.init(name: "insertedAfter", value: insertedAfter))
+        }
+        if let insertedBefore = query.insertedBefore?.queryStringEncoded {
+            queryItems.append(.init(name: "insertedBefore", value: insertedBefore))
+        }
         if let stepIdentifiers = query.stepIdentifiers?.commaDelimitedQueryValue {
             queryItems.append(.init(name: "stepIdentifier", value: stepIdentifiers))
         }

--- a/MyDataHelpsKit/API/URLRequests.swift
+++ b/MyDataHelpsKit/API/URLRequests.swift
@@ -101,6 +101,18 @@ extension URLRequest {
     }
 }
 
+extension HTTPURLResponse {
+    /// Shim for `value(forHTTPHeaderField:)` which is iOS 13-only.
+    func headerValue(field: String) -> String? {
+        if #available(iOS 13.0, *) {
+            return value(forHTTPHeaderField: field)
+        } else {
+            // Cast to NSDictionary so key lookup is case-insensitive
+            return (allHeaderFields as NSDictionary)[field] as? String
+        }
+    }
+}
+
 extension Collection where Element == String {
     var commaDelimitedQueryValue: String? {
         guard !isEmpty else { return nil }

--- a/MyDataHelpsKit/Model/APIRateLimit.swift
+++ b/MyDataHelpsKit/Model/APIRateLimit.swift
@@ -1,0 +1,34 @@
+//
+//  APIRateLimit.swift
+//  MyDataHelpsKit
+//
+//  Created by CareEvolution on 3/2/22.
+//
+
+import Foundation
+
+/// Information about MyDataHelps API request limits (throttling).
+///
+/// MyDataHelps API endpoints may limit the number of requests per hour, counting the cumulative number of requests in hourly intervals per project or similar scope, and resetting the counter at the end of each interval. If the limit is exceeded, requests will fail until the next scheduled reset time. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
+///
+/// The properties of APIRateLimit should be considered approximate and may have changed before your app reads them, for example due to other clients making concurrent requests.
+public struct APIRateLimit {
+    /// Maximum number of requests allowed per hour for this client or MyDataHelps project.
+    public let maxRequestsPerHour: Int
+    /// Approximate number of API requests remaining until the limit is exceeded.
+    public let remainingRequests: Int
+    /// Indicates the approximate time the request limit counter will be reset. If your API interactions are failing with the `tooManyRequests` error, they should work again if you retry after the `nextReset` date.
+    public let nextReset: Date
+    
+    init?(response: HTTPURLResponse) {
+        guard let limit = response.headerValue(field: "RateLimit-Limit").flatMap({ Int($0) }),
+              let remaining = response.headerValue(field: "RateLimit-Remaining").flatMap({ Int($0) }),
+              let reset = response.headerValue(field: "RateLimit-Reset").flatMap({ Int($0) }) else {
+                  return nil
+              }
+        
+        self.maxRequestsPerHour = limit
+        self.remainingRequests = remaining
+        self.nextReset = Date(timeIntervalSinceNow: TimeInterval(reset))
+    }
+}

--- a/MyDataHelpsKit/Model/APIRateLimit.swift
+++ b/MyDataHelpsKit/Model/APIRateLimit.swift
@@ -9,11 +9,11 @@ import Foundation
 
 /// Information about MyDataHelps API request limits (throttling).
 ///
-/// MyDataHelps API endpoints may limit the frequency of incoming requests, counting the cumulative number of requests in hourly intervals per project or similar scope, and resetting the counter at the end of each interval. If the limit is exceeded, requests will fail until the next scheduled reset time. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
+/// The MyDataHelps API has a rate limiting feature to preserve stability for all customers. The API counts the cumulative number of requests in hourly intervals per participant or similar scope, resetting the counter at the end of each interval. If the limit is exceeded within a short timeframe, requests will fail until the next scheduled reset. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
 ///
 /// The properties of APIRateLimit should be considered approximate and may have changed before your app reads them, for example due to other clients making concurrent requests.
 public struct APIRateLimit {
-    /// Maximum number of requests allowed per hour for this client or MyDataHelps project.
+    /// Maximum number of requests allowed per hour for this client or MyDataHelps project. Exact rate limits will vary based on project licensing and scope.
     public let maxRequestsPerHour: Int
     /// Approximate number of API requests remaining until the limit is exceeded.
     public let remainingRequests: Int

--- a/MyDataHelpsKit/Model/APIRateLimit.swift
+++ b/MyDataHelpsKit/Model/APIRateLimit.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Information about MyDataHelps API request limits (throttling).
 ///
-/// MyDataHelps API endpoints may limit the number of requests per hour, counting the cumulative number of requests in hourly intervals per project or similar scope, and resetting the counter at the end of each interval. If the limit is exceeded, requests will fail until the next scheduled reset time. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
+/// MyDataHelps API endpoints may limit the frequency of incoming requests, counting the cumulative number of requests in hourly intervals per project or similar scope, and resetting the counter at the end of each interval. If the limit is exceeded, requests will fail until the next scheduled reset time. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
 ///
 /// The properties of APIRateLimit should be considered approximate and may have changed before your app reads them, for example due to other clients making concurrent requests.
 public struct APIRateLimit {

--- a/MyDataHelpsKit/Model/APIRateLimit.swift
+++ b/MyDataHelpsKit/Model/APIRateLimit.swift
@@ -7,17 +7,15 @@
 
 import Foundation
 
-/// Information about MyDataHelps API request limits (throttling).
+/// Information about MyDataHelps API request limits (throttling). The MyDataHelps API has a rate limiting feature to preserve stability for all customers. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
 ///
-/// The MyDataHelps API has a rate limiting feature to preserve stability for all customers. The API counts the cumulative number of requests in hourly intervals per participant or similar scope, resetting the counter at the end of each interval. If the limit is exceeded within a short timeframe, requests will fail until the next scheduled reset. Failures due to rate limiting are indicated by the `MyDataHelpsError.tooManyRequests` error case.
-///
-/// The properties of APIRateLimit should be considered approximate and may have changed before your app reads them, for example due to other clients making concurrent requests.
+/// The properties of APIRateLimit help you understand your rate limits and usage, which may vary based on project licensing and scope. See [Rate Limits documentation](https://developer.rkstudio.careevolution.com/api/limits.html) for additional information.
 public struct APIRateLimit {
-    /// Maximum number of requests allowed per hour for this client or MyDataHelps project. Exact rate limits will vary based on project licensing and scope.
+    /// Number of requests allowed per hour (total) for this scope.
     public let maxRequestsPerHour: Int
-    /// Approximate number of API requests remaining until the limit is exceeded.
+    /// Number of requests remaining this hour for this scope.
     public let remainingRequests: Int
-    /// Indicates the approximate time the request limit counter will be reset. If your API interactions are failing with the `tooManyRequests` error, they should work again if you retry after the `nextReset` date.
+    /// When the rate limit will be reset. If your API interactions are failing with the `tooManyRequests` error, they should work again if you retry after the `nextReset` date.
     public let nextReset: Date
     
     init?(response: HTTPURLResponse) {

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -22,6 +22,10 @@ public struct DeviceDataQuery: PagedQuery {
     public let observedAfter: Date?
     /// Date before which the device data was observed.
     public let observedBefore: Date?
+    /// Date after which the device data was modified.
+    public let modifiedAfter: Date?
+    /// Date before which the device data was modified.
+    public let modifiedBefore: Date?
     
     /// Maximum number of results per page. Default and maximum value is 100.
     public let limit: Int
@@ -34,13 +38,17 @@ public struct DeviceDataQuery: PagedQuery {
     ///   - types: Filter by one or more types/categories within the given namespace, e.g. "HeartRate".
     ///   - observedAfter: Date after which the device data was observed.
     ///   - observedBefore: Date before which the device data was observed.
+    ///   - modifiedAfter: Date after which the device data was observed.
+    ///   - modifiedBefore: Date before which the device data was observed.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of data to fetch.
-    public init(namespace: DeviceDataNamespace, types: Set<String>? = nil, observedAfter: Date? = nil, observedBefore: Date? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(namespace: DeviceDataNamespace, types: Set<String>? = nil, observedAfter: Date? = nil, observedBefore: Date? = nil, modifiedAfter: Date? = nil, modifiedBefore: Date? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
         self.namespace = namespace
         self.types = types
         self.observedAfter = observedAfter
         self.observedBefore = observedBefore
+        self.modifiedAfter = modifiedAfter
+        self.modifiedBefore = modifiedBefore
         self.limit = Self.clampedLimit(limit, max: Self.defaultLimit)
         self.pageID = pageID
     }
@@ -50,7 +58,7 @@ public struct DeviceDataQuery: PagedQuery {
     /// - Returns: A query for results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: DeviceDataResultPage) -> DeviceDataQuery? {
         guard let nextPageID = page.nextPageID else { return nil }
-        return DeviceDataQuery(namespace: namespace, types: types, observedAfter: observedAfter, observedBefore: observedBefore, limit: limit, pageID: nextPageID)
+        return DeviceDataQuery(namespace: namespace, types: types, observedAfter: observedAfter, observedBefore: observedBefore, modifiedAfter: modifiedAfter, modifiedBefore: modifiedBefore, limit: limit, pageID: nextPageID)
     }
 }
 

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -10,6 +10,8 @@ import Foundation
 /// Specifies filtering and page-navigation criteria for device data point queries.
 ///
 /// All query properties are optional. Set non-nil/non-default values only for the properties you want to use for filtering.
+///
+/// You can filter device data by two different type of dates: `modifiedBefore/After` and `observedBefore/After`. Due to variations and limitations in device data synchronization, it is possible for older data points to turn up in the system unpredictably. Using the "observed" query parameters will search based on the date the data was observed or recorded by the device, while the "modified" parameters will search based on the date it arrived in the system. Use the `modifiedAfter` property to search for data that has arrived since a prior query.
 public struct DeviceDataQuery: PagedQuery {
     /// The default and maximum number of results per page.
     public static let defaultLimit = 100
@@ -18,13 +20,13 @@ public struct DeviceDataQuery: PagedQuery {
     public let namespace: DeviceDataNamespace
     /// Filter by one or more types/categories within the given namespace, e.g. "HeartRate"
     public let types: Set<String>?
-    /// Date after which the device data was observed.
+    /// Search for device data points observed after this date.
     public let observedAfter: Date?
-    /// Date before which the device data was observed.
+    /// Search for device data points observed before this date.
     public let observedBefore: Date?
-    /// Date after which the device data was last modified.
+    /// Search for device data points updated in the system after this date.
     public let modifiedAfter: Date?
-    /// Date before which the device data was last modified.
+    /// Search for device data points updated in the system before this date.
     public let modifiedBefore: Date?
     
     /// Maximum number of results per page. Default and maximum value is 100.
@@ -36,10 +38,10 @@ public struct DeviceDataQuery: PagedQuery {
     /// - Parameters:
     ///   - namespace: Specifies the source framework for the device data.
     ///   - types: Filter by one or more types/categories within the given namespace, e.g. "HeartRate".
-    ///   - observedAfter: Date after which the device data was observed.
-    ///   - observedBefore: Date before which the device data was observed.
-    ///   - modifiedAfter: Date after which the device data was last modified.
-    ///   - modifiedBefore: Date before which the device data was last modified.
+    ///   - observedAfter: Search for device data points observed after this date.
+    ///   - observedBefore: Search for device data points observed before this date.
+    ///   - modifiedAfter: Search for device data points updated in the system after this date.
+    ///   - modifiedBefore: Search for device data points updated in the system before this date.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of data to fetch.
     public init(namespace: DeviceDataNamespace, types: Set<String>? = nil, observedAfter: Date? = nil, observedBefore: Date? = nil, modifiedAfter: Date? = nil, modifiedBefore: Date? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
@@ -115,7 +117,7 @@ public struct DeviceDataPoint: Decodable {
     public let deviceDataContextID: String?
     /// Date when the data point was first added.
     public let insertedDate: Date
-    /// Date when the data point was last modified.
+    /// Date when the data point was last updated in the system.
     public let modifiedDate: Date
     /// String used to name a device data point.
     public let identifier: String?

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -22,9 +22,9 @@ public struct DeviceDataQuery: PagedQuery {
     public let observedAfter: Date?
     /// Date before which the device data was observed.
     public let observedBefore: Date?
-    /// Date after which the device data was modified.
+    /// Date after which the device data was last modified.
     public let modifiedAfter: Date?
-    /// Date before which the device data was modified.
+    /// Date before which the device data was last modified.
     public let modifiedBefore: Date?
     
     /// Maximum number of results per page. Default and maximum value is 100.
@@ -38,8 +38,8 @@ public struct DeviceDataQuery: PagedQuery {
     ///   - types: Filter by one or more types/categories within the given namespace, e.g. "HeartRate".
     ///   - observedAfter: Date after which the device data was observed.
     ///   - observedBefore: Date before which the device data was observed.
-    ///   - modifiedAfter: Date after which the device data was observed.
-    ///   - modifiedBefore: Date before which the device data was observed.
+    ///   - modifiedAfter: Date after which the device data was last modified.
+    ///   - modifiedBefore: Date before which the device data was last modified.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of data to fetch.
     public init(namespace: DeviceDataNamespace, types: Set<String>? = nil, observedAfter: Date? = nil, observedBefore: Date? = nil, modifiedAfter: Date? = nil, modifiedBefore: Date? = nil, limit: Int = defaultLimit, pageID: String? = nil) {

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -61,23 +61,31 @@ public struct DeviceDataResultPage: PagedResult, Decodable {
     /// An ID to be used with subsequent `DeviceDataQuery` requests. Results from queries using this ID as the `pageID` parameter will show the next page of results. `nil` if there isn't a next page.
     public let nextPageID: String?
 }
-
-/// Specifies the source framework for the device data.
+    
+/// Device data is grouped into namespaces, which represent the source frameworks that generate the data. There is also a separate `project` namespace, where projects can persist their own data. The static members of DeviceDataNamespace identify all supported namespace values.
 public struct DeviceDataNamespace: RawRepresentable, Equatable, Decodable {
     public typealias RawValue = String
     
-    /// Data imported from a linked Apple Health account.
-    public static let appleHealth = DeviceDataNamespace(rawValue: "AppleHealth")
-    /// Data imported from a linked Fitbit account.
-    public static let fitbit = DeviceDataNamespace(rawValue: "Fitbit")
-    /// Data imported from a linked Google Fit account.
-    public static let googleFit = DeviceDataNamespace(rawValue: "GoogleFit")
-    /// Air quality index data imported from AirNow.gov.
-    public static let airNowApi = DeviceDataNamespace(rawValue: "AirNowApi")
-    /// Weather forecast data imported from WeatherBit.io.
-    public static let weatherBit = DeviceDataNamespace(rawValue: "WeatherBit")
     /// Data persisted by the Persist Device Data Points operation.
     public static let project = DeviceDataNamespace(rawValue: "Project")
+    
+    /// Data imported from a linked Fitbit account.
+    public static let fitbit = DeviceDataNamespace(rawValue: "Fitbit")
+    
+    /// Data imported from a linked Apple Health account.
+    public static let appleHealth = DeviceDataNamespace(rawValue: "AppleHealth")
+    
+    /// Data imported from a linked Google Fit account.
+    public static let googleFit = DeviceDataNamespace(rawValue: "GoogleFit")
+    
+    /// Air quality index data imported from AirNow.gov.
+    public static let airNowApi = DeviceDataNamespace(rawValue: "AirNowApi")
+    
+    /// Weather forecast data imported from WeatherBit.io.
+    public static let weatherBit = DeviceDataNamespace(rawValue: "WeatherBit")
+    
+    /// Data imported from Omron wellness products.
+    public static let omron = DeviceDataNamespace(rawValue: "Omron")
     
     /// The raw value for the namespace as stored in RKStudio.
     public let rawValue: String

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -76,7 +76,7 @@ public struct DeviceDataResultPage: PagedResult, Decodable {
 public struct DeviceDataNamespace: RawRepresentable, Equatable, Decodable {
     public typealias RawValue = String
     
-    /// Data persisted by the Persist Device Data Points operation.
+    /// Project-specific device data.
     public static let project = DeviceDataNamespace(rawValue: "Project")
     
     /// Data imported from a linked Fitbit account.

--- a/MyDataHelpsKit/Model/MyDataHelpsError.swift
+++ b/MyDataHelpsKit/Model/MyDataHelpsError.swift
@@ -18,11 +18,11 @@ public enum MyDataHelpsError: Error {
     case encodingError(Error)
     /// Unexpected server error, e.g. an HTTP 500 error.
     case serverError(HTTPResponseError)
-    /// API request limit exceeded. The associated `APIRateLimit` indicates when throttling will reset, and the `HTTPResponseError` may include an error message (non-localized) suitable for debugging.
+    /// Server request limit exceeded. The associated `APIRateLimit` indicates when throttling will reset, and the `HTTPResponseError` may include an error message (non-localized) suitable for debugging.
     case tooManyRequests(APIRateLimit, HTTPResponseError)
     /// A server request timed out.
     case timedOut(Error)
-    /// An API request had a missing or invalid access token. The access token should be refreshed and a new `ParticipantSession` created, if applicable.
+    /// A server request had a missing or invalid access token. The access token should be refreshed and a new `ParticipantSession` created, if applicable.
     case unauthorizedRequest(HTTPResponseError)
     /// Web content (e.g. an embeddable survey) unexpectedly failed to load, due to a network, server, or web content failure. Includes any underlying error, if available.
     case webContentError(Error?)

--- a/MyDataHelpsKit/Model/MyDataHelpsError.swift
+++ b/MyDataHelpsKit/Model/MyDataHelpsError.swift
@@ -18,6 +18,8 @@ public enum MyDataHelpsError: Error {
     case encodingError(Error)
     /// Unexpected server error, e.g. an HTTP 500 error.
     case serverError(HTTPResponseError)
+    /// API request limit exceeded. The associated `APIRateLimit` indicates when throttling will reset, and the `HTTPResponseError` may include an error message (non-localized) suitable for debugging.
+    case tooManyRequests(APIRateLimit, HTTPResponseError)
     /// A server request timed out.
     case timedOut(Error)
     /// An API request had a missing or invalid access token. The access token should be refreshed and a new `ParticipantSession` created, if applicable.

--- a/MyDataHelpsKit/Model/MyDataHelpsError.swift
+++ b/MyDataHelpsKit/Model/MyDataHelpsError.swift
@@ -16,9 +16,9 @@ public enum MyDataHelpsError: Error {
     case decodingError(Error)
     /// Failure to encode a model object.
     case encodingError(Error)
-    /// Unexpected server error, e.g. an HTTP 500 error.
+    /// Unexpected server error, e.g. an HTTP 500 error. Check the included `HTTPResponseError` for details, and [contact support](https://developer.rkstudio.careevolution.com/help.html) if you need help determining the problem.
     case serverError(HTTPResponseError)
-    /// Server request limit exceeded. The associated `APIRateLimit` indicates when throttling will reset, and the `HTTPResponseError` may include an error message (non-localized) suitable for debugging.
+    /// Server request limit exceeded. The associated `APIRateLimit` indicates when throttling will reset, and the `HTTPResponseError` may include an error message (non-localized) suitable for debugging. [Contact support](https://developer.rkstudio.careevolution.com/help.html) with any questions.
     case tooManyRequests(APIRateLimit, HTTPResponseError)
     /// A server request timed out.
     case timedOut(Error)

--- a/MyDataHelpsKit/Model/ParticipantInfo.swift
+++ b/MyDataHelpsKit/Model/ParticipantInfo.swift
@@ -77,4 +77,14 @@ public struct ParticipantDemographics: Decodable {
     public let gender: ParticipantGender?
     /// Participant's local time zone represented as a UTC offset, e.g., "-04:00:00".
     public let utcOffset: String?
+    /// Participant's local time zone identifier, e.g. `"America/New_York"`.
+    public let timeZone: String?
+    
+    /// The raw decodable value: "true" or "false".
+    private let unsubscribedFromEmails: String?
+    
+    /// Indicates that the participant has unsubscribed from email notifications.
+    public var isUnsubscribedFromEmails: Bool {
+        unsubscribedFromEmails == "true"
+    }
 }

--- a/MyDataHelpsKit/Model/ParticipantInfo.swift
+++ b/MyDataHelpsKit/Model/ParticipantInfo.swift
@@ -83,7 +83,7 @@ public struct ParticipantDemographics: Decodable {
     /// The raw decodable value: "true" or "false".
     private let unsubscribedFromEmails: String?
     
-    /// Indicates that the participant has unsubscribed from email notifications.
+    /// Indicates that the participant has unsubscribed from MyDataHelps email notifications.
     public var isUnsubscribedFromEmails: Bool {
         unsubscribedFromEmails == "true"
     }

--- a/MyDataHelpsKit/Model/ParticipantInfo.swift
+++ b/MyDataHelpsKit/Model/ParticipantInfo.swift
@@ -9,6 +9,10 @@ import Foundation
 
 /// Information about a participant.
 public struct ParticipantInfo: Decodable {
+    /// Auto-generated internal ID for the participant.
+    public let participantID: String
+    /// Auto-generated internal ID for the project.
+    public let projectID: String
     /// Project-specific participant identifier.
     public let participantIdentifier: String
     /// Project-specific secondary identifier.

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -20,10 +20,14 @@ public struct SurveyAnswersQuery: PagedQuery {
     public let surveyID: String?
     /// Filter by one or more internal names of the surveys in RKStudio which have the answers.
     public let surveyNames: Set<String>?
-    /// Date before which survey answers were submitted.
+    /// Date after which individual survey answers were recorded by the participant.
     public let after: Date?
-    /// Date after which survey answers were submitted.
+    /// Date before which individual survey answers were recorded by the participant
     public let before: Date?
+    /// Date after which the entire survey was submitted.
+    public let insertedAfter: Date?
+    /// Date before which the entire survey was submitted.
+    public let insertedBefore: Date?
     /// Filter by one or more identifiers for the survey steps for which answers were submitted.
     public let stepIdentifiers: Set<String>?
     /// Filter by one or more identifiers for the result provided to a survey step, and which contain survey answers.
@@ -41,19 +45,23 @@ public struct SurveyAnswersQuery: PagedQuery {
     ///   - surveyResultID: Auto-generated, globally-unique identifier for the survey submission containing the answer.
     ///   - surveyID: Auto-generated, globally-unique identifier for the survey containing the step the answer was provided for.
     ///   - surveyNames: Filter by one or more internal names of the surveys in RKStudio which have the answers.
-    ///   - after: Date before which survey answers were submitted.
-    ///   - before: Date after which survey answers were submitted.
+    ///   - after: Date after which individual survey answers were recorded by the participant.
+    ///   - before: Date before which individual survey answers were recorded by the participant.
+    ///   - insertedAfter: Date after which the entire survey was submitted.
+    ///   - insertedBefore: Date before which the entire survey was submitted.
     ///   - stepIdentifiers: Filter by one or more identifiers for the survey steps for which answers were submitted.
     ///   - resultIdentifiers: Filter by one or more identifiers for the result provided to a survey step, and which contain survey answers.
     ///   - answers: Filter by one or more specific text values the answer contains.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of survey answers to fetch.
-    public init(surveyResultID: String? = nil, surveyID: String? = nil, surveyNames: Set<String>? = nil, after: Date? = nil, before: Date? = nil, stepIdentifiers: Set<String>? = nil, resultIdentifiers: Set<String>? = nil, answers: Set<String>? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(surveyResultID: String? = nil, surveyID: String? = nil, surveyNames: Set<String>? = nil, after: Date? = nil, before: Date? = nil, insertedAfter: Date? = nil, insertedBefore: Date? = nil, stepIdentifiers: Set<String>? = nil, resultIdentifiers: Set<String>? = nil, answers: Set<String>? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
         self.surveyResultID = surveyResultID
         self.surveyID = surveyID
         self.surveyNames = surveyNames
         self.after = after
         self.before = before
+        self.insertedAfter = insertedAfter
+        self.insertedBefore = insertedBefore
         self.stepIdentifiers = stepIdentifiers
         self.resultIdentifiers = resultIdentifiers
         self.answers = answers
@@ -66,7 +74,7 @@ public struct SurveyAnswersQuery: PagedQuery {
     /// - Returns: A query for results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: SurveyAnswersPage) -> SurveyAnswersQuery? {
         guard let nextPageID = page.nextPageID else { return nil }
-        return SurveyAnswersQuery(surveyResultID: surveyResultID, surveyID: surveyID, surveyNames: surveyNames, after: after, before: before, stepIdentifiers: stepIdentifiers, resultIdentifiers: resultIdentifiers, answers: answers, limit: limit, pageID: nextPageID)
+        return SurveyAnswersQuery(surveyResultID: surveyResultID, surveyID: surveyID, surveyNames: surveyNames, after: after, before: before, insertedAfter: insertedAfter, insertedBefore: insertedBefore, stepIdentifiers: stepIdentifiers, resultIdentifiers: resultIdentifiers, answers: answers, limit: limit, pageID: nextPageID)
     }
 }
 
@@ -94,8 +102,10 @@ public struct SurveyAnswer: Decodable {
     public let surveyName: String
     /// Name of the survey displayed to the participant.
     public let surveyDisplayName: String
-    /// Date and time at which the survey answer was submitted. Different from the time at which the whole survey was submitted.
+    /// Date and time at which the survey answer was recorded by the participant.
     public let date: Date?
+    /// Date and time at which the entire survey was submitted.
+    public let insertedDate: Date
     /// Identifier for the survey step for which the answer was submitted.
     public let stepIdentifier: String
     /// Identifier for the result provided to a survey step, and which contains this survey answer.

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -10,6 +10,8 @@ import Foundation
 /// Specifies filtering and page-navigation criteria for survey answers.
 ///
 /// All query properties are optional. Set non-nil/non-default values only for the properties you want to use for filtering.
+///
+/// You can filter survey answers by two different types of dates: `before/after` and `insertedBefore/After`. The former properties use the date the answer was recorded by the participant; the latter ones use the date the answer was submitted to the system. The dates may be appreciably different if the participant started a survey, answered a few questions, and then submitted it much later. There may also be minor variations due to the participant's device time compared to the server time. Use the `insertedAfter` property to search for new answers since a prior query.
 public struct SurveyAnswersQuery: PagedQuery {
     /// The default and maximum number of results per page.
     public static let defaultLimit = 100
@@ -20,13 +22,13 @@ public struct SurveyAnswersQuery: PagedQuery {
     public let surveyID: String?
     /// Filter by one or more internal names of the surveys in RKStudio which have the answers.
     public let surveyNames: Set<String>?
-    /// Date after which individual survey answers were recorded by the participant.
+    /// Search for answers recorded by the participant after a specific date.
     public let after: Date?
-    /// Date before which individual survey answers were recorded by the participant.
+    /// Search for answers recorded by the participant before a specific date.
     public let before: Date?
-    /// Date after which the entire survey was submitted.
+    /// Search for answers submitted to the system after a specific date.
     public let insertedAfter: Date?
-    /// Date before which the entire survey was submitted.
+    /// Search for answers submitted to the system before a specific date.
     public let insertedBefore: Date?
     /// Filter by one or more identifiers for the survey steps for which answers were submitted.
     public let stepIdentifiers: Set<String>?
@@ -45,10 +47,10 @@ public struct SurveyAnswersQuery: PagedQuery {
     ///   - surveyResultID: Auto-generated, globally-unique identifier for the survey submission containing the answer.
     ///   - surveyID: Auto-generated, globally-unique identifier for the survey containing the step the answer was provided for.
     ///   - surveyNames: Filter by one or more internal names of the surveys in RKStudio which have the answers.
-    ///   - after: Date after which individual survey answers were recorded by the participant.
-    ///   - before: Date before which individual survey answers were recorded by the participant.
-    ///   - insertedAfter: Date after which the entire survey was submitted.
-    ///   - insertedBefore: Date before which the entire survey was submitted.
+    ///   - after: Search for answers recorded by the participant after a specific date.
+    ///   - before: Search for answers recorded by the participant before a specific date.
+    ///   - insertedAfter: Search for answers submitted to the system after a specific date.
+    ///   - insertedBefore: Search for answers submitted to the system before a specific date.
     ///   - stepIdentifiers: Filter by one or more identifiers for the survey steps for which answers were submitted.
     ///   - resultIdentifiers: Filter by one or more identifiers for the result provided to a survey step, and which contain survey answers.
     ///   - answers: Filter by one or more specific text values the answer contains.
@@ -104,7 +106,7 @@ public struct SurveyAnswer: Decodable {
     public let surveyDisplayName: String
     /// Date and time at which the survey answer was recorded by the participant.
     public let date: Date?
-    /// Date and time at which the entire survey was submitted.
+    /// Date and time at which the was submitted to the system.
     public let insertedDate: Date
     /// Identifier for the survey step for which the answer was submitted.
     public let stepIdentifier: String

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -22,7 +22,7 @@ public struct SurveyAnswersQuery: PagedQuery {
     public let surveyNames: Set<String>?
     /// Date after which individual survey answers were recorded by the participant.
     public let after: Date?
-    /// Date before which individual survey answers were recorded by the participant
+    /// Date before which individual survey answers were recorded by the participant.
     public let before: Date?
     /// Date after which the entire survey was submitted.
     public let insertedAfter: Date?

--- a/MyDataHelpsKitTests/APIRateLimitTests.swift
+++ b/MyDataHelpsKitTests/APIRateLimitTests.swift
@@ -1,0 +1,55 @@
+//
+//  APIRateLimitTests.swift
+//  MyDataHelpsKitTests
+//
+//  Created by CareEvolution on 3/2/22.
+//
+
+import XCTest
+@testable import MyDataHelpsKit
+
+class APIRateLimitTests: XCTestCase {
+    func testInit() {
+        let url = MyDataHelpsClient().baseURL
+        var response = HTTPURLResponse(url: url, statusCode: 429, httpVersion: "HTTP/1.1", headerFields: [:])!
+        
+        XCTAssertNil(APIRateLimit(response: response), "Returns nil when expected headers are missing")
+        
+        response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: [
+            "RateLimit-Limit": "789",
+            "RateLimit-Remaining": "321",
+            "RateLimit-Reset": "20"
+        ])!
+        
+        var limit = APIRateLimit(response: response)
+        var expectedReset = Date().addingTimeInterval(20)
+        XCTAssertNotNil(limit, "Parsed limit info from valid headers")
+        if let limit = limit {
+            XCTAssertEqual(limit.maxRequestsPerHour, 789)
+            XCTAssertEqual(limit.remainingRequests, 321)
+            XCTAssertEqual(limit.nextReset.timeIntervalSince(expectedReset), 0, accuracy: 1)
+        }
+        
+        response = HTTPURLResponse(url: url, statusCode: 429, httpVersion: "HTTP/1.1", headerFields: [
+            "ratelimit-limit": "1337",
+            "ratelimit-remaining": "0",
+            "ratelimit-reset": "200"
+        ])!
+        
+        limit = APIRateLimit(response: response)
+        expectedReset = Date().addingTimeInterval(200)
+        XCTAssertNotNil(limit, "Parsed limit info from case-insensitive headers")
+        if let limit = limit {
+            XCTAssertEqual(limit.maxRequestsPerHour, 1337)
+            XCTAssertEqual(limit.remainingRequests, 0)
+            XCTAssertEqual(limit.nextReset.timeIntervalSince(expectedReset), 0, accuracy: 1)
+        }
+        
+        response = HTTPURLResponse(url: url, statusCode: 429, httpVersion: "HTTP/1.1", headerFields: [
+            "RateLimit-Limit": "bogus",
+            "RateLimit-Remaining": "bogus",
+            "RateLimit-Reset": "bogus"
+        ])!
+        XCTAssertNil(APIRateLimit(response: response), "Returns nil with invalid headers")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [GitHub releases](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releas
 4. Create a `ParticipantSession` using the access token. This is the primary interface for interacting with MyDataHelps. It can be retained for as long as the participant's acess token is valid; create a new `ParticipantSession` when you renew the access token or when a different participant logs in
 5. Use `ParticipantSession` functions to perform MyDataHelps operations and requests for the participant
 
-See [online documentation](https://developer.rkstudio.careevolution.com/ios) or integrated Xcode symbol documentation for details about specfic operations and model types.
+See [online documentation](https://developer.rkstudio.careevolution.com/ios) or integrated Xcode symbol documentation for details about specific operations and model types.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [GitHub releases](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releas
 
 1. Add MyDataHelpsKit to your Xcode workspace. See the [installation](#installation) section below for details
 2. Create a `MyDataHelpsClient` object for communication with RKStudio/MyDataHelps. This object can be retained for the lifetime of your app
-3. Obtain an access token for the authorized MyDataHelps participant. Note that your app is responsible for renewing the access token when it expires
+3. Obtain a [participant access token](https://developer.rkstudio.careevolution.com/sdk/participant_tokens.html) for the authorized MyDataHelps participant. Note that your app is responsible for renewing the access token when it expires
 4. Create a `ParticipantSession` using the access token. This is the primary interface for interacting with MyDataHelps. It can be retained for as long as the participant's acess token is valid; create a new `ParticipantSession` when you renew the access token or when a different participant logs in
 5. Use `ParticipantSession` functions to perform MyDataHelps operations and requests for the participant
 
@@ -20,12 +20,12 @@ Example:
 
 ```swift
 import MyDataHelpsKit
-// Get a token for an authenticated MyDataHelps user within your app
+// Get participant access token for an authenticated MyDataHelps user within your app.
 let tokenString = getAccessToken()
-// Initialize a MyDataHelpsKit client and session using the access token
+// Initialize a MyDataHelpsKit client and session using the access token.
 let client = MyDataHelpsClient()
 let session = ParticipantSession(client: client, accessToken: .init(token: tokenString))
-// Example of using MyDataHelpsKit functionality
+// Example of using MyDataHelpsKit functionality:
 session.getParticipantInfo { result in
     switch result {
     case let .success(model):

--- a/example/MyDataHelpsKit-Example.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit-Example.xcscheme
+++ b/example/MyDataHelpsKit-Example.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/MyDataHelpsKit-Example/ErrorView.swift
+++ b/example/MyDataHelpsKit-Example/ErrorView.swift
@@ -22,6 +22,14 @@ struct ErrorView: View {
                 return "Encoding error: \(underlying.localizedDescription)"
             case let .serverError(underlying):
                 return "Server error: HTTP \(underlying.statusCode): \(underlying.message ?? underlying.localizedDescription)"
+            case let .tooManyRequests(limit, underlying):
+                let resetDate: String
+                if #available(iOS 15.0, *) {
+                    resetDate = limit.nextReset.formatted(.dateTime.hour().minute().second())
+                } else {
+                    resetDate = "\(limit.nextReset)"
+                }
+                return "Too many requests: exceeded \(limit.maxRequestsPerHour), reset at \(resetDate) [\(underlying.message ?? "")]"
             case let .timedOut(underlying):
                 return "Timed out: \(underlying.localizedDescription)"
             case let .unauthorizedRequest(underlying):

--- a/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
@@ -14,6 +14,7 @@ struct ParticipantInfoViewModel {
     let email: String?
     let phone: String?
     let enrollmentDate: Date?
+    let isUnsubscribedFromEmails: Bool
 }
 
 extension ParticipantInfoViewModel {
@@ -25,6 +26,7 @@ extension ParticipantInfoViewModel {
         self.email = info.demographics.email
         self.phone = info.demographics.mobilePhone
         self.enrollmentDate = info.enrollmentDate
+        self.isUnsubscribedFromEmails = info.demographics.isUnsubscribedFromEmails
     }
 }
 
@@ -43,7 +45,7 @@ struct ParticipantInfoView: View {
             Text(model.name)
                 .font(.headline)
             if let email = model.email {
-                Text(email)
+                Label(email, systemImage: model.isUnsubscribedFromEmails ? "slash.circle" : "checkmark.circle")
             }
             if let phone = model.phone {
                 Text(phone)
@@ -64,6 +66,7 @@ struct ParticipantInfoView_Previews: PreviewProvider {
                 linkIdentifier: nil,
                 email: nil,
                 phone: "555-555-1212",
-                enrollmentDate: Date().addingTimeInterval(-86400)))
+                enrollmentDate: Date().addingTimeInterval(-86400),
+                isUnsubscribedFromEmails: true))
     }
 }

--- a/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
@@ -43,7 +43,7 @@ class ParticipantSessionPreview: ParticipantSessionType {
     }
     
     func getParticipantInfoViewModel(completion: @escaping (Result<ParticipantInfoViewModel, MyDataHelpsError>) -> Void) {
-        completion(.success(.init(name: "name", linkIdentifier: nil, email: "email", phone: "phone", enrollmentDate: Date())))
+        completion(.success(.init(name: "name", linkIdentifier: nil, email: "email", phone: "phone", enrollmentDate: Date(), isUnsubscribedFromEmails: false)))
     }
     
     func queryDeviceData(_ query: DeviceDataQuery, completion: @escaping (Result<DeviceDataResultPage, MyDataHelpsError>) -> Void) {


### PR DESCRIPTION
## Overview

- Closes #26: introduces a new MyDataHelpsError case for HTTP 429 "too many requests" errors.
- Closes #25: Adds projectID and participantID to the ParticipantInfo model.
- Adds timeZone and unsubscribedFromEmails to ParticipantDemographics model.
- Adds the `omron` DeviceDataNamespace.
- Adds support for filtering device data by modified date. I tested this in the example app with some hard-coded queries but did not commit those changes.
- Adds insertedDate to SurveyAnswer model, and support for filtering answers by insertedDate. I tested this in the example app with some hard-coded queries but did not commit those changes.
- Various minor documentation fixes.

I tested all of the changes in the example app; some tests were temporary hard-coded query changes that I did not commit: the example app is not designed to interactively exercise possible single query filter, and developers are explicitly encouraged to hack around in the example code to explore whatever data and filters are relevant to them.

The APIRateLimit metadata included in the `tooManyRequests` error is also available in the headers of most successful API endpoint responses. We could consider reporting this to the client with every API request/response, such as via a delegate of ParticipantSession, but I had a hard time forming a concrete use case for this. Something to keep in mind for future consideration.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated

New outputs: various properties added to existing result models. Basic string/date parsing using existing decoder implementations, no concerns here.

New inputs: various date filters added to existing query APIs. Follows the same encoding implementation as other existing inputs, no concerns here.

## Checklist

- [X] All public symbols are documented using Swift Markup comments
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy"
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
