### PR TITLE
Update base URL

### DIFF
--- a/MyDataHelpsKit/MyDataHelpsClient.swift
+++ b/MyDataHelpsKit/MyDataHelpsClient.swift
@@ -15,7 +15,7 @@ public final class MyDataHelpsClient {
     public static let SDKVersion = MyDataHelpsKitVersion
     
     /// Default base URL to use for MyDataHelps API requests.
-    private static let defaultBaseURL = URL(string: "https://rkstudio.careevolution.com/ppt/")!
+    private static let defaultBaseURL = URL(string: "https://mydatahelps.org/")!
     private static let requestTimeoutInterval: TimeInterval = 30
     
     internal let baseURL: URL

--- a/MyDataHelpsKitTests/MyDataHelpsClientTests.swift
+++ b/MyDataHelpsKitTests/MyDataHelpsClientTests.swift
@@ -11,13 +11,13 @@ import XCTest
 class MyDataHelpsClientTests: XCTestCase {
     func testDefaultBaseURL() {
         let sut = MyDataHelpsClient()
-        XCTAssertEqual(sut.baseURL.absoluteString, "https://rkstudio.careevolution.com/ppt/", "Default client uses correct base URL")
+        XCTAssertEqual(sut.baseURL.absoluteString, "https://mydatahelps.org/", "Default client uses correct base URL")
     }
     
     func testEndpoint() {
         var sut = MyDataHelpsClient()
         var url = sut.endpoint(path: "example/path/1")
-        XCTAssertEqual(url.absoluteString, "https://rkstudio.careevolution.com/ppt/example/path/1", "Default client uses correct base URL in endpoint URLs")
+        XCTAssertEqual(url.absoluteString, "https://mydatahelps.org/example/path/1", "Default client uses correct base URL in endpoint URLs")
         
         sut = MyDataHelpsClient(baseURL: URL(string: "https://example.com/api/")!)
         url = sut.endpoint(path: "example/path/2")
@@ -28,10 +28,10 @@ class MyDataHelpsClientTests: XCTestCase {
     func testEndpointWithQueryItems() {
         let sut = MyDataHelpsClient()
         var url = try? sut.endpoint(path: "example", queryItems: [])
-        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/example?")
+        XCTAssertEqual(url?.absoluteString, "https://mydatahelps.org/example?")
         
         url = try? sut.endpoint(path: "example/path", queryItems: [.init(name: "a", value: "b")])
-        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/example/path?a=b")
+        XCTAssertEqual(url?.absoluteString, "https://mydatahelps.org/example/path?a=b")
     }
     
     func testEmbeddableURLs() {
@@ -41,8 +41,8 @@ class MyDataHelpsClientTests: XCTestCase {
         let taskLinkID = UUID().uuidString
         let languageTag = sut.languageTag
         var url = try? sut.embeddableSurveyURL(surveyName: surveyName, participantLinkIdentifier: participantLinkID).get()
-        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/mydatahelps/\(participantLinkID)/surveylink/\(surveyName)?lang=\(languageTag)")
+        XCTAssertEqual(url?.absoluteString, "https://mydatahelps.org/mydatahelps/\(participantLinkID)/surveylink/\(surveyName)?lang=\(languageTag)")
         url = try? sut.embeddableSurveyURL(taskLinkIdentifier: taskLinkID, participantLinkIdentifier: participantLinkID).get()
-        XCTAssertEqual(url?.absoluteString, "https://rkstudio.careevolution.com/ppt/mydatahelps/\(participantLinkID)/tasklink/\(taskLinkID)?lang=\(languageTag)")
+        XCTAssertEqual(url?.absoluteString, "https://mydatahelps.org/mydatahelps/\(participantLinkID)/tasklink/\(taskLinkID)?lang=\(languageTag)")
     }
 }


### PR DESCRIPTION
## Overview

Per #31, updates the default base URL to mydatahelps.org. No changes visible to consumers of the SDK: just changes the default value used in the default initializer of MyDataHelpsClient. I already tested this change in the example app.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

_No security implication: no functional changes here, just correcting the URL for API requests._

## Checklist

- [X] All public symbols are documented using Swift Markup comments.
- [X] If this feature requires a developer doc update, tag CareEvolution/api-docs. _\[No documentation changes to make\]_
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
