### PR TITLE
Type-safe identifiers

### DIFF
--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		AC02E68425FA7FCD008A46E4 /* SurveyTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E68325FA7FCD008A46E4 /* SurveyTasks.swift */; };
 		AC02E68825FA8056008A46E4 /* SurveyTaskQueryResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E68725FA8056008A46E4 /* SurveyTaskQueryResource.swift */; };
 		AC02E69C25FAA979008A46E4 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E69B25FAA979008A46E4 /* Diagnostics.swift */; };
+		AC2DAB1028A6CFE00023035E /* ScopedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */; };
+		AC2DAB3528AD16D90023035E /* ScopedIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */; };
 		AC77B4BE25E8495C00427294 /* MyDataHelpsKit.h in Headers */ = {isa = PBXBuildFile; fileRef = AC77B4BC25E8495C00427294 /* MyDataHelpsKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC77B50125E8502000427294 /* MyDataHelpsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC77B50025E8502000427294 /* MyDataHelpsClient.swift */; };
 		AC77B50425E8523500427294 /* ParticipantSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC77B50325E8523500427294 /* ParticipantSession.swift */; };
@@ -58,6 +60,8 @@
 		AC02E68325FA7FCD008A46E4 /* SurveyTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyTasks.swift; sourceTree = "<group>"; };
 		AC02E68725FA8056008A46E4 /* SurveyTaskQueryResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyTaskQueryResource.swift; sourceTree = "<group>"; };
 		AC02E69B25FAA979008A46E4 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
+		AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifier.swift; sourceTree = "<group>"; };
+		AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifierTests.swift; sourceTree = "<group>"; };
 		AC77B4B925E8495C00427294 /* MyDataHelpsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MyDataHelpsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC77B4BC25E8495C00427294 /* MyDataHelpsKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyDataHelpsKit.h; sourceTree = "<group>"; };
 		AC77B4BD25E8495C00427294 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -160,6 +164,7 @@
 				AC9DC9B52609064800C5D9E4 /* NotificationHistory.swift */,
 				AC83ABCC25E991E300A668E4 /* PagedQuery.swift */,
 				AC77B50C25E854E600427294 /* ParticipantInfo.swift */,
+				AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */,
 				AC9DC99F26052AEA00C5D9E4 /* SurveyAnswers.swift */,
 				AC02E68325FA7FCD008A46E4 /* SurveyTasks.swift */,
 			);
@@ -201,6 +206,7 @@
 				ACEAF44D26D683F7002F79AB /* ExternalAccountsTests.swift */,
 				AC83ABDD25F131DA00A668E4 /* Info.plist */,
 				AC9DC9BF260A876F00C5D9E4 /* MyDataHelpsClientTests.swift */,
+				AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */,
 				AC83ABDB25F131DA00A668E4 /* URLRequestsTests.swift */,
 			);
 			path = MyDataHelpsKitTests;
@@ -281,7 +287,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					AC77B4B825E8495C00427294 = {
 						CreatedOnToolsVersion = 12.4;
@@ -368,6 +374,7 @@
 				AC932351265D9874007AAF69 /* EmbeddableSurveyViewController.swift in Sources */,
 				AC77B50125E8502000427294 /* MyDataHelpsClient.swift in Sources */,
 				ACEAF45926DD7E76002F79AB /* ConnectExternalAccountResource.swift in Sources */,
+				AC2DAB1028A6CFE00023035E /* ScopedIdentifier.swift in Sources */,
 				AC83ABB925E867E100A668E4 /* DeviceDataQueryResource.swift in Sources */,
 				AC83ABB125E85BB900A668E4 /* GetParticipantInfoResource.swift in Sources */,
 				AC77B50925E8535B00427294 /* ParticipantAccessToken.swift in Sources */,
@@ -389,6 +396,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AC2DAB3528AD16D90023035E /* ScopedIdentifierTests.swift in Sources */,
 				AC83ABDC25F131DA00A668E4 /* URLRequestsTests.swift in Sources */,
 				AC9DC9C0260A876F00C5D9E4 /* MyDataHelpsClientTests.swift in Sources */,
 				ACBF66C627CFE18800BC6945 /* APIRateLimitTests.swift in Sources */,

--- a/MyDataHelpsKit.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit.xcscheme
+++ b/MyDataHelpsKit.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MyDataHelpsKit/API/ConnectExternalAccountResource.swift
+++ b/MyDataHelpsKit/API/ConnectExternalAccountResource.swift
@@ -10,7 +10,7 @@ import Foundation
 struct ConnectExternalAccountResource: ParticipantResource {
     typealias ResponseType = URL
     
-    let providerID: Int
+    let providerID: ExternalAccountProvider.ID
     let finalRedirectURL: URL
 
     func urlRequest(session: ParticipantSession) throws -> URLRequest {

--- a/MyDataHelpsKit/API/DeleteSurveyResultResource.swift
+++ b/MyDataHelpsKit/API/DeleteSurveyResultResource.swift
@@ -10,11 +10,11 @@ import Foundation
 struct DeleteSurveyResultResource: ParticipantResource {
     typealias ResponseType = Void
     
-    let surveyResultID: String
+    let surveyResultID: SurveyResult.ID
     
     func urlRequest(session: ParticipantSession) throws -> URLRequest {
         // Ensure it's a valid UUID so we can produce a safe URL path
-        guard let id = UUID(uuidString: surveyResultID) else {
+        guard let id = UUID(uuidString: surveyResultID.value) else {
             throw EncodingError.invalidValue(surveyResultID, .init(codingPath: [], debugDescription: "surveyResultID should be a UUID"))
         }
         return session.authenticatedRequest(.DELETE, url: session.client.endpoint(path: "api/v1/delegated/surveyresults/\(id.uuidString)"))

--- a/MyDataHelpsKit/API/DeviceDataQueryResource.swift
+++ b/MyDataHelpsKit/API/DeviceDataQueryResource.swift
@@ -33,7 +33,7 @@ struct DeviceDataQueryResource: ParticipantResource {
         
         queryItems.append(.init(name: "limit", value: "\(query.limit)"))
         if let pageID = query.pageID {
-            queryItems.append(.init(name: "pageID", value: pageID))
+            queryItems.append(.init(name: "pageID", value: pageID.value))
         }
         
         let url = try session.client.endpoint(path: "api/v1/delegated/devicedata", queryItems: queryItems)

--- a/MyDataHelpsKit/API/NotificationHistoryQueryResource.swift
+++ b/MyDataHelpsKit/API/NotificationHistoryQueryResource.swift
@@ -33,7 +33,7 @@ struct NotificationHistoryQueryResource: ParticipantResource {
         
         queryItems.append(.init(name: "limit", value: "\(query.limit)"))
         if let pageID = query.pageID {
-            queryItems.append(.init(name: "pageID", value: pageID))
+            queryItems.append(.init(name: "pageID", value: pageID.value))
         }
         
         return session.authenticatedRequest(.GET, url: try session.client.endpoint(path: "api/v1/delegated/notifications", queryItems: queryItems))

--- a/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
@@ -15,10 +15,10 @@ struct SurveyAnswersQueryResource: ParticipantResource {
     func urlRequest(session: ParticipantSession) throws -> URLRequest {
         var queryItems: [URLQueryItem] = []
         if let surveyResultID = query.surveyResultID {
-            queryItems.append(.init(name: "surveyResultID", value: surveyResultID))
+            queryItems.append(.init(name: "surveyResultID", value: surveyResultID.value))
         }
         if let surveyID = query.surveyID {
-            queryItems.append(.init(name: "surveyID", value: surveyID))
+            queryItems.append(.init(name: "surveyID", value: surveyID.value))
         }
         if let surveyNames = query.surveyNames?.commaDelimitedQueryValue {
             queryItems.append(.init(name: "surveyName", value: surveyNames))

--- a/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
@@ -47,7 +47,7 @@ struct SurveyAnswersQueryResource: ParticipantResource {
         
         queryItems.append(.init(name: "limit", value: "\(query.limit)"))
         if let pageID = query.pageID {
-            queryItems.append(.init(name: "pageID", value: pageID))
+            queryItems.append(.init(name: "pageID", value: pageID.value))
         }
         
         let url = try session.client.endpoint(path: "api/v1/delegated/surveyanswers", queryItems: queryItems)

--- a/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
@@ -32,7 +32,7 @@ struct SurveyTaskQueryResource: ParticipantResource {
         
         queryItems.append(.init(name: "limit", value: "\(query.limit)"))
         if let pageID = query.pageID {
-            queryItems.append(.init(name: "pageID", value: pageID))
+            queryItems.append(.init(name: "pageID", value: pageID.value))
         }
         
         let url = try session.client.endpoint(path: "api/v1/delegated/surveytasks", queryItems: queryItems)

--- a/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
@@ -18,7 +18,7 @@ struct SurveyTaskQueryResource: ParticipantResource {
             queryItems.append(.init(name: "status", value: statuses))
         }
         if let surveyID = query.surveyID {
-            queryItems.append(.init(name: "surveyID", value: surveyID))
+            queryItems.append(.init(name: "surveyID", value: surveyID.value))
         }
         if let surveyNames = query.surveyNames?.commaDelimitedQueryValue {
             queryItems.append(.init(name: "surveyName", value: surveyNames))

--- a/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
@@ -24,7 +24,7 @@ struct SurveyTaskQueryResource: ParticipantResource {
             queryItems.append(.init(name: "surveyName", value: surveyNames))
         }
         if let linkIdentifier = query.linkIdentifier {
-            queryItems.append(.init(name: "linkIdentifier", value: linkIdentifier))
+            queryItems.append(.init(name: "linkIdentifier", value: linkIdentifier.value))
         }
         if let sortOrder = query.sortOrder {
             queryItems.append(.init(name: "sortOrder", value: sortOrder.rawValue))

--- a/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
+++ b/MyDataHelpsKit/Embeddables/EmbeddableSurveyViewController.swift
@@ -59,7 +59,7 @@ public final class EmbeddableSurveyViewController: UIViewController {
     ///   - taskLinkIdentifier: Identifies the survey task to present to the participant. This is the `linkIdentifier` property of `SurveyTask`, as retrieved via `ParticipantSession.querySurveyTasks`.
     ///   - participantLinkIdentifier: Auto-generated participant identifier used to complete surveys via link. This is the `linkIdentifier` property of `ParticipantInfo`, as retrieved via `ParticipantSession.getParticipantInfo`.
     ///   - completion: Called when the participant has completed interaction with the survey. The completion callback must always dismiss the EmbeddableSurveyViewController.
-    public init(client: MyDataHelpsClient, taskLinkIdentifier: String, participantLinkIdentifier: String, completion: @escaping (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void) {
+    public init(client: MyDataHelpsClient, taskLinkIdentifier: SurveyTaskLink.ID, participantLinkIdentifier: ParticipantLink.ID, completion: @escaping (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void) {
         self.surveyURL = client.embeddableSurveyURL(taskLinkIdentifier: taskLinkIdentifier, participantLinkIdentifier: participantLinkIdentifier)
         self.languageTag = client.languageTag
         self.userAgent = client.userAgent
@@ -77,7 +77,7 @@ public final class EmbeddableSurveyViewController: UIViewController {
     ///   - surveyName: The name of the survey to present.
     ///   - participantLinkIdentifier: Auto-generated participant identifier used to complete surveys via link. This is the `linkIdentifier` property of `ParticipantInfo`, as retrieved via `ParticipantSession.getParticipantInfo`.
     ///   - completion: Called when the participant has completed interaction with the survey. The completion callback must always dismiss the EmbeddableSurveyViewController.
-    public init(client: MyDataHelpsClient, surveyName: String, participantLinkIdentifier: String, completion: @escaping (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void) {
+    public init(client: MyDataHelpsClient, surveyName: String, participantLinkIdentifier: ParticipantLink.ID, completion: @escaping (Result<EmbeddableSurveyCompletionReason, MyDataHelpsError>) -> Void) {
         self.surveyURL = client.embeddableSurveyURL(surveyName: surveyName, participantLinkIdentifier: participantLinkIdentifier)
         self.languageTag = client.languageTag
         self.userAgent = client.userAgent
@@ -208,7 +208,7 @@ extension EmbeddableSurveyViewController: WKNavigationDelegate {
 #endif
 
 internal extension MyDataHelpsClient {
-    func embeddableSurveyURL(taskLinkIdentifier: String, participantLinkIdentifier: String) -> Result<URL, MyDataHelpsError> {
+    func embeddableSurveyURL(taskLinkIdentifier: SurveyTaskLink.ID, participantLinkIdentifier: ParticipantLink.ID) -> Result<URL, MyDataHelpsError> {
         do {
             let url = try endpoint(path: "mydatahelps/\(participantLinkIdentifier)/tasklink/\(taskLinkIdentifier)", queryItems: [.init(name: "lang", value: languageTag)])
             return .success(url)
@@ -217,7 +217,7 @@ internal extension MyDataHelpsClient {
         }
     }
     
-    func embeddableSurveyURL(surveyName: String, participantLinkIdentifier: String) -> Result<URL, MyDataHelpsError> {
+    func embeddableSurveyURL(surveyName: String, participantLinkIdentifier: ParticipantLink.ID) -> Result<URL, MyDataHelpsError> {
         do {
             let url = try endpoint(path: "mydatahelps/\(participantLinkIdentifier)/surveylink/\(surveyName)", queryItems: [.init(name: "lang", value: languageTag)])
             return .success(url)

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -109,6 +109,14 @@ public struct DeviceDataNamespace: RawRepresentable, Equatable, Decodable {
     }
 }
 
+/// Container for the `DeviceDataContext.ID` identifier type, which identifies a group of device data points.
+///
+/// The ``DeviceDataContext`` struct itself is empty and no instances are returned by any APIs.
+public struct DeviceDataContext {
+    /// Auto-generated, globally-unique identifier for a group of device data points, which share some context.
+    public typealias ID = ScopedIdentifier<DeviceDataContext, String>
+}
+
 /// A single device data point stored in MyDataHelps.
 public struct DeviceDataPoint: Identifiable, Decodable {
     /// Auto-generated, globally-unique identifier for a DeviceDataPoint.
@@ -119,7 +127,7 @@ public struct DeviceDataPoint: Identifiable, Decodable {
     /// Identifies device data as from a specific source system.
     public let namespace: DeviceDataNamespace
     /// Auto-generated, globally-unique identifier for a group of device data points, which share some context.
-    public let deviceDataContextID: String?
+    public let deviceDataContextID: DeviceDataContext.ID?
     /// Date when the data point was first added.
     public let insertedDate: Date
     /// Date when the data point was last updated in the system.

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -109,6 +109,7 @@ public struct DeviceDataNamespace: RawRepresentable, Equatable, Decodable {
 
 /// A single device data point stored in MyDataHelps.
 public struct DeviceDataPoint: Identifiable, Decodable {
+    /// Auto-generated, globally-unique identifier for a DeviceDataPoint.
     public typealias ID = ScopedIdentifier<DeviceDataPoint, String>
     
     /// Auto-generated, globally-unique identifier.

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -108,9 +108,11 @@ public struct DeviceDataNamespace: RawRepresentable, Equatable, Decodable {
 }
 
 /// A single device data point stored in MyDataHelps.
-public struct DeviceDataPoint: Decodable {
+public struct DeviceDataPoint: Identifiable, Decodable {
+    public typealias ID = ScopedIdentifier<DeviceDataPoint, String>
+    
     /// Auto-generated, globally-unique identifier.
-    public let id: String
+    public let id: ID
     /// Identifies device data as from a specific source system.
     public let namespace: DeviceDataNamespace
     /// Auto-generated, globally-unique identifier for a group of device data points, which share some context.

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -32,7 +32,7 @@ public struct DeviceDataQuery: PagedQuery {
     /// Maximum number of results per page. Default and maximum value is 100.
     public let limit: Int
     /// Identifies a specific page of data to fetch. Use `nil` to fetch the first page of results. To fetch the page following a given `DeviceDataResultPage` use its `nextPageID`; the other parameters should be the same as the original `DeviceDataQuery`.
-    public let pageID: String?
+    public let pageID: DeviceDataResultPage.PageID?
     
     /// Initializes a new query for a page of device data with various filters.
     /// - Parameters:
@@ -44,7 +44,7 @@ public struct DeviceDataQuery: PagedQuery {
     ///   - modifiedBefore: Search for device data points updated in the system before this date.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of data to fetch.
-    public init(namespace: DeviceDataNamespace, types: Set<String>? = nil, observedAfter: Date? = nil, observedBefore: Date? = nil, modifiedAfter: Date? = nil, modifiedBefore: Date? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(namespace: DeviceDataNamespace, types: Set<String>? = nil, observedAfter: Date? = nil, observedBefore: Date? = nil, modifiedAfter: Date? = nil, modifiedBefore: Date? = nil, limit: Int = defaultLimit, pageID: DeviceDataResultPage.PageID? = nil) {
         self.namespace = namespace
         self.types = types
         self.observedAfter = observedAfter
@@ -66,10 +66,12 @@ public struct DeviceDataQuery: PagedQuery {
 
 /// A page of device data points.
 public struct DeviceDataResultPage: PagedResult, Decodable {
+    /// Identifies a specific page of device data points.
+    public typealias PageID = ScopedIdentifier<DeviceDataResultPage, String>
     /// A list of DeviceDataPoints filtered by the query criteria.
     public let deviceDataPoints: [DeviceDataPoint]
     /// An ID to be used with subsequent `DeviceDataQuery` requests. Results from queries using this ID as the `pageID` parameter will show the next page of results. `nil` if there isn't a next page.
-    public let nextPageID: String?
+    public let nextPageID: PageID?
 }
     
 /// Device data is grouped into namespaces, which represent the source frameworks that generate the data. There is also a separate `project` namespace, where projects can persist their own data. The static members of DeviceDataNamespace identify all supported namespace values.

--- a/MyDataHelpsKit/Model/NotificationHistory.swift
+++ b/MyDataHelpsKit/Model/NotificationHistory.swift
@@ -157,6 +157,7 @@ public enum NotificationContent {
 
 /// Information about a notification for a participant.
 public struct NotificationHistoryModel: Identifiable, Decodable {
+    /// Auto-generated, globally-unique identifier for a NotificationHistoryModel.
     public typealias ID = ScopedIdentifier<NotificationHistoryModel, String>
     
     enum CodingKeys: String, CodingKey {

--- a/MyDataHelpsKit/Model/NotificationHistory.swift
+++ b/MyDataHelpsKit/Model/NotificationHistory.swift
@@ -156,7 +156,8 @@ public enum NotificationContent {
 }
 
 /// Information about a notification for a participant.
-public struct NotificationHistoryModel: Decodable {
+public struct NotificationHistoryModel: Identifiable, Decodable {
+    public typealias ID = ScopedIdentifier<NotificationHistoryModel, String>
     
     enum CodingKeys: String, CodingKey {
         case id
@@ -168,7 +169,7 @@ public struct NotificationHistoryModel: Decodable {
     }
     
     /// Auto-generated, globally-unique identifier for this notification.
-    public let id: String
+    public let id: ID
     /// Identifier for the notification configuration.
     public let identifier: String
     /// If the notification was sent, the date at which the notification was sent.
@@ -186,7 +187,7 @@ public struct NotificationHistoryModel: Decodable {
     /// - Throws: DecodingError on failure to decode.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.id = try container.decode(String.self, forKey: .id)
+        self.id = try container.decode(ID.self, forKey: .id)
         self.identifier = try container.decode(String.self, forKey: .identifier)
         self.sentDate = try container.decode(Date.self, forKey: .sentDate)
         self.statusCode = try container.decode(NotificationSendStatusCode.self, forKey: .statusCode)

--- a/MyDataHelpsKit/Model/NotificationHistory.swift
+++ b/MyDataHelpsKit/Model/NotificationHistory.swift
@@ -27,8 +27,8 @@ public struct NotificationHistoryQuery: PagedQuery {
     
     /// Maximum number of results per page. Default and maximum value is 100.
     public let limit: Int
-    /// Identifies a specific page of survey answers to fetch. Use `nil` to fetch the first page of results. To fetch the page following a given `SurveyAnswersPage` use its `nextPageID`; the other parameters should be the same as the original `SurveyAnswersQuery`.
-    public let pageID: String?
+    /// Identifies a specific page of notifications to fetch. Use `nil` to fetch the first page of results. To fetch the page following a given `NotificationHistoryPage` use its `nextPageID`; the other parameters should be the same as the original `NotificationHistoryQuery`.
+    public let pageID: NotificationHistoryPage.PageID?
     
     /// Initializes a new query for a page of notifications with various filters.
     /// - Parameters:
@@ -38,8 +38,8 @@ public struct NotificationHistoryQuery: PagedQuery {
     ///   - type: Type of notification.
     ///   - statusCode: Describes whether the notification was sent.
     ///   - limit: Maximum number of results per page.
-    ///   - pageID: Identifies a specific page of survey answers to fetch.
-    public init(identifier: String? = nil, sentAfter: Date? = nil, sentBefore: Date? = nil, type: NotificationType? = nil, statusCode: NotificationSendStatusCode? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    ///   - pageID: Identifies a specific page of notifications to fetch.
+    public init(identifier: String? = nil, sentAfter: Date? = nil, sentBefore: Date? = nil, type: NotificationType? = nil, statusCode: NotificationSendStatusCode? = nil, limit: Int = defaultLimit, pageID: NotificationHistoryPage.PageID? = nil) {
         self.identifier = identifier
         self.sentAfter = sentAfter
         self.sentBefore = sentBefore
@@ -60,10 +60,12 @@ public struct NotificationHistoryQuery: PagedQuery {
 
 /// A page of notifications.
 public struct NotificationHistoryPage: PagedResult, Decodable {
+    /// Identifies a specific page of notifications.
+    public typealias PageID = ScopedIdentifier<NotificationHistoryPage, String>
     /// A list of notifications filtered by the query criteria.
     public let notifications: [NotificationHistoryModel]
     /// An ID to be used with subsequent `NotificationHistoryQuery` requests. Results from queries using this ID as the `pageID` parameter will show the next page of results. `nil` if there isn't a next page.
-    public let nextPageID: String?
+    public let nextPageID: PageID?
 }
 
 /// The type of notification sent to a participant.

--- a/MyDataHelpsKit/Model/PagedQuery.swift
+++ b/MyDataHelpsKit/Model/PagedQuery.swift
@@ -12,7 +12,7 @@ internal protocol PagedQuery {
     /// The model type of the result object.
     associatedtype ResultType: PagedResult
     /// Identifies a specific page of data to fetch. Use `nil` to fetch the first page of results.
-    var pageID: String? { get }
+    var pageID: ScopedIdentifier<ResultType, String>? { get }
     /// Should initialize a new request for a page of results following the given page, with the same filters as the original query.
     func page(after page: ResultType) -> Self?
 }
@@ -20,7 +20,7 @@ internal protocol PagedQuery {
 /// API response model that represents a paged collection of results.
 internal protocol PagedResult {
     /// The `pageID` to use to fetch the next page of results.
-    var nextPageID: String? { get }
+    var nextPageID: ScopedIdentifier<Self, String>? { get }
 }
 
 extension PagedQuery {

--- a/MyDataHelpsKit/Model/ParticipantInfo.swift
+++ b/MyDataHelpsKit/Model/ParticipantInfo.swift
@@ -7,18 +7,37 @@
 
 import Foundation
 
+/// Container for the `Project.ID` identifier type, which identifies a project in MyDataHelps.
+///
+/// The ``Project`` struct itself is empty and no instances are returned by any APIs.
+public struct Project {
+    /// Auto-generated internal ID for a project in MyDataHelps.
+    public typealias ID = ScopedIdentifier<Project, String>
+}
+
+/// Container for the `ParticipantLink.ID` identifier type, which identifies a participant link identifier in MyDataHelps.
+///
+/// The ``ParticipantLink`` struct itself is empty and no instances are returned by any APIs.
+public struct ParticipantLink {
+    /// Auto-generated identifier used to complete surveys via link for a specific participant, if that feature is enabled for the project.
+    public typealias ID = ScopedIdentifier<ParticipantLink, String>
+}
+
 /// Information about a participant.
 public struct ParticipantInfo: Decodable {
+    /// Auto-generated internal ID for a participant.
+    public typealias ID = ScopedIdentifier<ParticipantInfo, String>
+    
     /// Auto-generated internal ID for the participant.
-    public let participantID: String
+    public let participantID: ID
     /// Auto-generated internal ID for the project.
-    public let projectID: String
+    public let projectID: Project.ID
     /// Project-specific participant identifier.
     public let participantIdentifier: String
     /// Project-specific secondary identifier.
     public let secondaryIdentifier: String?
     /// Auto-generated identifier used to complete surveys via link, if that feature is enabled for the project.
-    public let linkIdentifier: String?
+    public let linkIdentifier: ParticipantLink.ID?
     /// All demographic fields populated for the participant. Unpopulated values are `nil`.
     public let demographics: ParticipantDemographics
     /// Key/value pairs representing project-specific custom fields.

--- a/MyDataHelpsKit/Model/ParticipantInfo.swift
+++ b/MyDataHelpsKit/Model/ParticipantInfo.swift
@@ -15,7 +15,7 @@ public struct Project {
     public typealias ID = ScopedIdentifier<Project, String>
 }
 
-/// Container for the `ParticipantLink.ID` identifier type, which identifies a participant link identifier in MyDataHelps.
+/// Container for the `ParticipantLink.ID` identifier type, for participant link identifiers.
 ///
 /// The ``ParticipantLink`` struct itself is empty and no instances are returned by any APIs.
 public struct ParticipantLink {

--- a/MyDataHelpsKit/Model/ScopedIdentifier.swift
+++ b/MyDataHelpsKit/Model/ScopedIdentifier.swift
@@ -1,0 +1,62 @@
+//
+//  ScopedIdentifier.swift
+//  MyDataHelpsKit
+//
+//  Created by CareEvolution on 8/12/22.
+//
+
+import Foundation
+
+/// A unique identifier associated with a specific model type (the `Subject`) in MyDataHelpsKit.
+///
+/// Most model types in this SDK have at least one identifier value, typically a string. It is an error
+/// to use the identifier from a model of type A when fetching, querying, or creating models of type B.
+/// ScopedIdentifiers prevent such mistakes by making it a compiler error to use a mismatched identifier.
+///
+/// For example, the following code mistakenly uses a `surveyID` to delete a survey result,
+/// instead of the `surveyResultID`. If allowed, this would fail to delete any survey result, or possibly delete
+/// the wrong survey result. ScopedIdentifiers prevents such a mistake from compiling,
+/// because surveyID and surveyResultID are incompatible `ScopedIdentifier` types.
+///
+/// ```swift
+/// func deleteSurveyResult(containing answer: SurveyAnswer) {
+///     // Will not compile, and would delete the wrong survey:
+///     // session.deleteSurveyResult(surveyResultID: answer.surveyID) { ... }
+///
+///     // Will compile and work correctly:
+///     session.deleteSurveyResult(surveyResultID: answer.surveyResultID) { ... }
+/// }
+/// ```
+public struct ScopedIdentifier<Subject, Value: Hashable>: Hashable {
+    /// The value of the identifier.
+    public let value: Value
+    
+    /// Initializes an identifier.
+    ///
+    /// Directly initializing a ScopedIdentifier is uncommon: typically, MyDataHelpsKit
+    /// will fetch model objects with existing identifiers from the server (e.g. via ``ParticipantSession``),
+    /// and the client will then use these existing identifiers in other API calls.
+    /// - Parameter value: The value of the identifier.
+    public init(_ value: Value) {
+        self.value = value
+    }
+}
+
+extension ScopedIdentifier: CustomStringConvertible where Value: CustomStringConvertible {
+    public var description: String {
+        value.description
+    }
+}
+
+extension ScopedIdentifier: Decodable where Value: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.value = try decoder.singleValueContainer().decode(Value.self)
+    }
+}
+
+extension ScopedIdentifier: Encodable where Value: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.value)
+    }
+}

--- a/MyDataHelpsKit/Model/ScopedIdentifier.swift
+++ b/MyDataHelpsKit/Model/ScopedIdentifier.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// A unique identifier associated with a specific model type (the `Subject`) in MyDataHelpsKit.
+/// A unique identifier associated with a specific model type (the `Subject`) in MyDataHelps.
 ///
 /// Most model types in this SDK have at least one identifier value, typically a string. It is an error
 /// to use the identifier from a model of type A when fetching, querying, or creating models of type B.

--- a/MyDataHelpsKit/Model/ScopedIdentifier.swift
+++ b/MyDataHelpsKit/Model/ScopedIdentifier.swift
@@ -21,10 +21,10 @@ import Foundation
 /// ```swift
 /// func deleteSurveyResult(containing answer: SurveyAnswer) {
 ///     // Will not compile, and would delete the wrong survey:
-///     // session.deleteSurveyResult(surveyResultID: answer.surveyID) { ... }
+///     // session.deleteSurveyResult(answer.surveyID) { ... }
 ///
 ///     // Will compile and work correctly:
-///     session.deleteSurveyResult(surveyResultID: answer.surveyResultID) { ... }
+///     session.deleteSurveyResult(answer.surveyResultID) { ... }
 /// }
 /// ```
 public struct ScopedIdentifier<Subject, Value: Hashable>: Hashable {

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -104,7 +104,7 @@ public struct SurveyAnswer: Identifiable, Decodable {
     /// Version number of the survey that the participant completed.
     public let surveyVersion: Int
     /// Auto-generated, globally-unique identifier for the task which prompted the participant to complete the survey, if any.
-    public let taskID: String?
+    public let taskID: SurveyTask.ID?
     /// Internal name for the survey in MyDataHelps.
     public let surveyName: String
     /// Name of the survey displayed to the participant.

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -17,9 +17,9 @@ public struct SurveyAnswersQuery: PagedQuery {
     public static let defaultLimit = 100
     
     /// Auto-generated, globally-unique identifier for the survey submission containing the answer.
-    public let surveyResultID: String?
+    public let surveyResultID: SurveyResult.ID?
     /// Auto-generated, globally-unique identifier for the survey containing the step the answer was provided for.
-    public let surveyID: String?
+    public let surveyID: Survey.ID?
     /// Filter by one or more internal names of the surveys which have the answers.
     public let surveyNames: Set<String>?
     /// Search for answers recorded by the participant after a specific date.
@@ -30,9 +30,9 @@ public struct SurveyAnswersQuery: PagedQuery {
     public let insertedAfter: Date?
     /// Search for answers submitted to the system before a specific date.
     public let insertedBefore: Date?
-    /// Filter by one or more identifiers for the survey steps for which answers were submitted.
+    /// Filter by one or more identifiers for the survey steps for which answers were submitted. Refers to the step identifier field in the MyDataHelps survey editor.
     public let stepIdentifiers: Set<String>?
-    /// Filter by one or more identifiers for the result provided to a survey step, and which contain survey answers.
+    /// Filter by one or more identifiers for the field on the survey step for which answers were submitted. Relevant for form steps, and refers to their form items’ identifier field.
     public let resultIdentifiers: Set<String>?
     /// Filter by one or more specific text values the answer contains.
     public let answers: Set<String>?
@@ -51,12 +51,12 @@ public struct SurveyAnswersQuery: PagedQuery {
     ///   - before: Search for answers recorded by the participant before a specific date.
     ///   - insertedAfter: Search for answers submitted to the system after a specific date.
     ///   - insertedBefore: Search for answers submitted to the system before a specific date.
-    ///   - stepIdentifiers: Filter by one or more identifiers for the survey steps for which answers were submitted.
-    ///   - resultIdentifiers: Filter by one or more identifiers for the result provided to a survey step, and which contain survey answers.
+    ///   - stepIdentifiers: Filter by one or more identifiers for the survey steps for which answers were submitted. Refers to the step identifier field in the MyDataHelps survey editor.
+    ///   - resultIdentifiers: Filter by one or more identifiers for the field on the survey step for which answers were submitted. Relevant for form steps, and refers to their form items’ identifier field.
     ///   - answers: Filter by one or more specific text values the answer contains.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of survey answers to fetch.
-    public init(surveyResultID: String? = nil, surveyID: String? = nil, surveyNames: Set<String>? = nil, after: Date? = nil, before: Date? = nil, insertedAfter: Date? = nil, insertedBefore: Date? = nil, stepIdentifiers: Set<String>? = nil, resultIdentifiers: Set<String>? = nil, answers: Set<String>? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(surveyResultID: SurveyResult.ID? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, after: Date? = nil, before: Date? = nil, insertedAfter: Date? = nil, insertedBefore: Date? = nil, stepIdentifiers: Set<String>? = nil, resultIdentifiers: Set<String>? = nil, answers: Set<String>? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
         self.surveyResultID = surveyResultID
         self.surveyID = surveyID
         self.surveyNames = surveyNames
@@ -89,13 +89,15 @@ public struct SurveyAnswersPage: PagedResult, Decodable {
 }
 
 /// A single survey answer completed by a participant.
-public struct SurveyAnswer: Decodable {
+public struct SurveyAnswer: Identifiable, Decodable {
+    public typealias ID = ScopedIdentifier<SurveyAnswer, String>
+    
     /// Auto-generated, globally-unique identifier.
-    public let id: String
+    public let id: ID
     /// Auto-generated, globally-unique identifier for the survey submission containing this answer.
-    public let surveyResultID: String
+    public let surveyResultID: SurveyResult.ID
     /// Auto-generated, globally-unique identifier for the survey containing the step this answer was provided for.
-    public let surveyID: String
+    public let surveyID: Survey.ID
     /// Version number of the survey that the participant completed.
     public let surveyVersion: Int
     /// Auto-generated, globally-unique identifier for the task which prompted the participant to complete the survey, if any.
@@ -110,7 +112,7 @@ public struct SurveyAnswer: Decodable {
     public let insertedDate: Date
     /// Identifier for the survey step for which the answer was submitted.
     public let stepIdentifier: String
-    /// Identifier for the result provided to a survey step, and which contains this survey answer.
+    /// Identifier for the field on the survey step which contains this survey answer.
     public let resultIdentifier: String
     /// List of answers contained in the result for this step of the survey.
     public let answers: [String]

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -90,6 +90,7 @@ public struct SurveyAnswersPage: PagedResult, Decodable {
 
 /// A single survey answer completed by a participant.
 public struct SurveyAnswer: Identifiable, Decodable {
+    /// Auto-generated, globally-unique identifier for a SurveyAnswer.
     public typealias ID = ScopedIdentifier<SurveyAnswer, String>
     
     /// Auto-generated, globally-unique identifier.

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -40,7 +40,7 @@ public struct SurveyAnswersQuery: PagedQuery {
     /// Maximum number of results per page. Default and maximum value is 100.
     public let limit: Int
     /// Identifies a specific page of survey answers to fetch. Use `nil` to fetch the first page of results. To fetch the page following a given `SurveyAnswersPage` use its `nextPageID`; the other parameters should be the same as the original `SurveyAnswersQuery`.
-    public let pageID: String?
+    public let pageID: SurveyAnswersPage.PageID?
     
     /// Initializes a new query for a page of survey answers with various filters.
     /// - Parameters:
@@ -56,7 +56,7 @@ public struct SurveyAnswersQuery: PagedQuery {
     ///   - answers: Filter by one or more specific text values the answer contains.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of survey answers to fetch.
-    public init(surveyResultID: SurveyResult.ID? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, after: Date? = nil, before: Date? = nil, insertedAfter: Date? = nil, insertedBefore: Date? = nil, stepIdentifiers: Set<String>? = nil, resultIdentifiers: Set<String>? = nil, answers: Set<String>? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(surveyResultID: SurveyResult.ID? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, after: Date? = nil, before: Date? = nil, insertedAfter: Date? = nil, insertedBefore: Date? = nil, stepIdentifiers: Set<String>? = nil, resultIdentifiers: Set<String>? = nil, answers: Set<String>? = nil, limit: Int = defaultLimit, pageID: SurveyAnswersPage.PageID? = nil) {
         self.surveyResultID = surveyResultID
         self.surveyID = surveyID
         self.surveyNames = surveyNames
@@ -82,10 +82,12 @@ public struct SurveyAnswersQuery: PagedQuery {
 
 /// A page of survey answers.
 public struct SurveyAnswersPage: PagedResult, Decodable {
+    /// Identifies a specific page of survey answers.
+    public typealias PageID = ScopedIdentifier<SurveyAnswersPage, String>
     /// A list of SurveyAnswers filtered by the query criteria.
     public let surveyAnswers: [SurveyAnswer]
     /// An ID to be used with subsequent `SurveyAnswersQuery` requests. Results from queries using this ID as the `pageID` parameter will show the next page of results. `nil` if there isn't a next page.
-    public let nextPageID: String?
+    public let nextPageID: PageID?
 }
 
 /// A single survey answer completed by a participant.

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -49,7 +49,7 @@ public struct SurveyTaskQuery: PagedQuery {
     /// Internal name for the survey in MyDataHelps which this task assigns. Filter by one or more values.
     public let surveyNames: Set<String>?
     /// Secure and unique identifier for the task, to be used publicly when providing links to a survey.
-    public let linkIdentifier: String?
+    public let linkIdentifier: SurveyTaskLink.ID?
     /// Return results in the specified order. Defaults to `dateDescending`.
     public let sortOrder: SortOrder?
     
@@ -67,7 +67,7 @@ public struct SurveyTaskQuery: PagedQuery {
     ///   - sortOrder: Return results in the specified order.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of survey tasks to fetch.
-    public init(statuses: Set<SurveyTaskStatus>? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, linkIdentifier: String? = nil, sortOrder: SurveyTaskQuery.SortOrder? = nil, limit: Int = defaultLimit, pageID: SurveyTaskResultPage.PageID? = nil) {
+    public init(statuses: Set<SurveyTaskStatus>? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, linkIdentifier: SurveyTaskLink.ID? = nil, sortOrder: SurveyTaskQuery.SortOrder? = nil, limit: Int = defaultLimit, pageID: SurveyTaskResultPage.PageID? = nil) {
         self.statuses = statuses
         self.surveyID = surveyID
         self.surveyNames = surveyNames
@@ -117,6 +117,14 @@ public struct SurveyTaskStatus: RawRepresentable, Equatable, Hashable, Decodable
     }
 }
 
+/// Container for the `SurveyTaskLink.ID` identifier type, which is used for generating links to a survey.
+///
+/// The ``SurveyTaskLink`` struct itself is empty and no instances are returned by any APIs.
+public struct SurveyTaskLink {
+    /// Secure and unique identifier for a SurveyTask, to be used publicly when providing links to a survey.
+    public typealias ID = ScopedIdentifier<SurveyTaskLink, String>
+}
+
 /// A single survey task assigned to a participant.
 public struct SurveyTask: Identifiable, Decodable {
     /// Auto-generated, globally-unique identifier for a SurveyTask.
@@ -125,7 +133,7 @@ public struct SurveyTask: Identifiable, Decodable {
     /// Auto-generated, globally-unique identifier.
     public let id: ID
     /// Secure and unique identifier for the task, to be used publicly when providing links to a survey.
-    public let linkIdentifier: String?
+    public let linkIdentifier: SurveyTaskLink.ID?
     /// Auto-generated, globally-unique identifier for the survey which this task assigns.
     public let surveyID: Survey.ID
     /// Internal name for the survey in MyDataHelps which this task assigns.

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -19,7 +19,7 @@ public struct Survey {
 
 /// Container for the `SurveyResult.ID` identifier type, which identifies a specific survey submission in MyDataHelps.
 ///
-/// The ``Survey`` struct itself is empty and no instances are returned by any APIs.
+/// The ``SurveyResult`` struct itself is empty and no instances are returned by any APIs.
 public struct SurveyResult {
     /// Identifies a specific survey submission in MyDataHelps.
     ///

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -117,6 +117,7 @@ public struct SurveyTaskStatus: RawRepresentable, Equatable, Hashable, Decodable
 
 /// A single survey task assigned to a participant.
 public struct SurveyTask: Identifiable, Decodable {
+    /// Auto-generated, globally-unique identifier for a SurveyTask.
     public typealias ID = ScopedIdentifier<SurveyTask, String>
     
     /// Auto-generated, globally-unique identifier.

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -56,7 +56,7 @@ public struct SurveyTaskQuery: PagedQuery {
     /// Maximum number of results per page. Default and maximum value is 100.
     public let limit: Int
     /// Identifies a specific page of survey tasks to fetch. Use `nil` to fetch the first page of results. To fetch the page following a given `SurveyTaskResultPage` use its `nextPageID`; the other parameters should be the same as the original `SurveyTaskQuery`.
-    public let pageID: String?
+    public let pageID: SurveyTaskResultPage.PageID?
     
     /// Initializes a new query for a page of survey tasks with various filters.
     /// - Parameters:
@@ -67,7 +67,7 @@ public struct SurveyTaskQuery: PagedQuery {
     ///   - sortOrder: Return results in the specified order.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of survey tasks to fetch.
-    public init(statuses: Set<SurveyTaskStatus>? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, linkIdentifier: String? = nil, sortOrder: SurveyTaskQuery.SortOrder? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(statuses: Set<SurveyTaskStatus>? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, linkIdentifier: String? = nil, sortOrder: SurveyTaskQuery.SortOrder? = nil, limit: Int = defaultLimit, pageID: SurveyTaskResultPage.PageID? = nil) {
         self.statuses = statuses
         self.surveyID = surveyID
         self.surveyNames = surveyNames
@@ -88,10 +88,12 @@ public struct SurveyTaskQuery: PagedQuery {
 
 /// A page of survey tasks.
 public struct SurveyTaskResultPage: PagedResult, Decodable {
+    /// Identifies a specific page of survey tasks.
+    public typealias PageID = ScopedIdentifier<SurveyTaskResultPage, String>
     /// A list of SurveyTasks filtered by the query criteria.
     public let surveyTasks: [SurveyTask]
     /// An ID to be used with subsequent `SurveyTaskQuery` requests. Results from queries using this ID as the `pageID` parameter will show the next page of results. `nil` if there isn't a next page.
-    public let nextPageID: String?
+    public let nextPageID: PageID?
 }
 
 /// Describes the status of a survey task assigned to a participant.

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -7,6 +7,26 @@
 
 import Foundation
 
+/// Container for the `Survey.ID` identifier type, which identifies a specific survey in MyDataHelps.
+///
+/// The ``Survey`` struct itself is empty and no instances are returned by any APIs.
+public struct Survey {
+    /// Identifies a specific survey in MyDataHelps.
+    ///
+    /// Used for ``SurveyTask`` and ``SurveyAnswer`` values, and related APIs.
+    public typealias ID = ScopedIdentifier<Survey, String>
+}
+
+/// Container for the `SurveyResult.ID` identifier type, which identifies a specific survey submission in MyDataHelps.
+///
+/// The ``Survey`` struct itself is empty and no instances are returned by any APIs.
+public struct SurveyResult {
+    /// Identifies a specific survey submission in MyDataHelps.
+    ///
+    /// Used for ``SurveyAnswer`` values and related APIs.
+    public typealias ID = ScopedIdentifier<SurveyResult, String>
+}
+
 /// Specifies filtering and page-navigation criteria for survey task queries.
 ///
 /// All query properties are optional. Set non-nil/non-default values only for the properties you want to use for filtering or sorting.
@@ -25,7 +45,7 @@ public struct SurveyTaskQuery: PagedQuery {
     /// Filter by one or more survey task status values.
     public let statuses: Set<SurveyTaskStatus>?
     /// Auto-generated, globally-unique identifier for the survey which this task assigns.
-    public let surveyID: String?
+    public let surveyID: Survey.ID?
     /// Internal name for the survey in MyDataHelps which this task assigns. Filter by one or more values.
     public let surveyNames: Set<String>?
     /// Secure and unique identifier for the task, to be used publicly when providing links to a survey.
@@ -47,7 +67,7 @@ public struct SurveyTaskQuery: PagedQuery {
     ///   - sortOrder: Return results in the specified order.
     ///   - limit: Maximum number of results per page.
     ///   - pageID: Identifies a specific page of survey tasks to fetch.
-    public init(statuses: Set<SurveyTaskStatus>? = nil, surveyID: String? = nil, surveyNames: Set<String>? = nil, linkIdentifier: String? = nil, sortOrder: SurveyTaskQuery.SortOrder? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
+    public init(statuses: Set<SurveyTaskStatus>? = nil, surveyID: Survey.ID? = nil, surveyNames: Set<String>? = nil, linkIdentifier: String? = nil, sortOrder: SurveyTaskQuery.SortOrder? = nil, limit: Int = defaultLimit, pageID: String? = nil) {
         self.statuses = statuses
         self.surveyID = surveyID
         self.surveyNames = surveyNames
@@ -96,13 +116,15 @@ public struct SurveyTaskStatus: RawRepresentable, Equatable, Hashable, Decodable
 }
 
 /// A single survey task assigned to a participant.
-public struct SurveyTask: Decodable {
+public struct SurveyTask: Identifiable, Decodable {
+    public typealias ID = ScopedIdentifier<SurveyTask, String>
+    
     /// Auto-generated, globally-unique identifier.
-    public let id: String
+    public let id: ID
     /// Secure and unique identifier for the task, to be used publicly when providing links to a survey.
     public let linkIdentifier: String?
     /// Auto-generated, globally-unique identifier for the survey which this task assigns.
-    public let surveyID: String
+    public let surveyID: Survey.ID
     /// Internal name for the survey in MyDataHelps which this task assigns.
     public let surveyName: String
     /// Name of the survey displayed to the participant, which this task assigns.

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
@@ -84,6 +84,7 @@ public struct ExternalAccountProviderCategory: RawRepresentable, Equatable, Hash
 ///
 /// Use `ParticipantSession.connectExternalAccount` to initiate a connected account between the participant and this provider.
 public struct ExternalAccountProvider: Identifiable, Decodable {
+    /// Assigned identifier for an ExternalAccountProvider.
     public typealias ID = ScopedIdentifier<ExternalAccountProvider, Int>
     
     enum CodingKeys: String, CodingKey {

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
@@ -83,7 +83,9 @@ public struct ExternalAccountProviderCategory: RawRepresentable, Equatable, Hash
 /// An external account provider supported by MyDataHelps.
 ///
 /// Use `ParticipantSession.connectExternalAccount` to initiate a connected account between the participant and this provider.
-public struct ExternalAccountProvider: Decodable {
+public struct ExternalAccountProvider: Identifiable, Decodable {
+    public typealias ID = ScopedIdentifier<ExternalAccountProvider, Int>
+    
     enum CodingKeys: String, CodingKey {
         case id = "id"
         case name = "name"
@@ -92,7 +94,7 @@ public struct ExternalAccountProvider: Decodable {
     }
     
     /// Assigned identifier for this external account provider.
-    public let id: Int
+    public let id: ID
     /// Name of the external account provider.
     public let name: String
     /// Type of account provider.

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccounts.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccounts.swift
@@ -61,6 +61,7 @@ public struct ExternalAccountStatus: RawRepresentable, Equatable, Hashable, Deco
 
 /// An external account that the participant is currently connected to.
 public struct ExternalAccount: Identifiable, Decodable {
+    /// Assigned identifier for an ExternalAccount.
     public typealias ID = ScopedIdentifier<ExternalAccount, Int>
     
     /// Assigned identifier for this connected external account.

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccounts.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccounts.swift
@@ -60,9 +60,11 @@ public struct ExternalAccountStatus: RawRepresentable, Equatable, Hashable, Deco
 }
 
 /// An external account that the participant is currently connected to.
-public struct ExternalAccount: Decodable {
+public struct ExternalAccount: Identifiable, Decodable {
+    public typealias ID = ScopedIdentifier<ExternalAccount, Int>
+    
     /// Assigned identifier for this connected external account.
-    public let id: Int
+    public let id: ID
     /// The current status for this connected external account.
     public let status: ExternalAccountStatus
     /// The provider for this external account.

--- a/MyDataHelpsKit/Session/ParticipantSession.swift
+++ b/MyDataHelpsKit/Session/ParticipantSession.swift
@@ -89,7 +89,7 @@ public final class ParticipantSession {
     /// - Parameters:
     ///   - surveyResultID: Auto-generated, globally-unique identifier for the survey submission to delete.
     ///   - completion: Called when the request is complete, with an empty `.success` on success or an error on failure.
-    public func deleteSurveyResult(surveyResultID: String, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void) {
+    public func deleteSurveyResult(_ surveyResultID: SurveyResult.ID, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void) {
         load(resource: DeleteSurveyResultResource(surveyResultID: surveyResultID), completion: completion)
     }
     

--- a/MyDataHelpsKitTests/ExternalAccountsTests.swift
+++ b/MyDataHelpsKitTests/ExternalAccountsTests.swift
@@ -25,7 +25,7 @@ class ExternalAccountsTests: XCTestCase {
         let list = try JSONDecoder.myDataHelpsDecoder.decode([ExternalAccount].self, from: accountsJSON)
         XCTAssertEqual(list.count, 1)
         if let first = list.first {
-            XCTAssertEqual(first.id, 100)
+            XCTAssertEqual(first.id.value, 100)
             XCTAssertEqual(first.status, .fetchComplete)
             XCTAssertEqual(first.provider.name, "MyDataHelps Demo Provider")
             XCTAssertEqual(first.provider.logoURL?.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
@@ -37,7 +37,7 @@ class ExternalAccountsTests: XCTestCase {
         let list = try JSONDecoder.myDataHelpsDecoder.decode([ExternalAccountProvider].self, from: providersJSON)
         XCTAssertEqual(list.count, 1)
         if let first = list.first {
-            XCTAssertEqual(first.id, 1)
+            XCTAssertEqual(first.id.value, 1)
             XCTAssertEqual(first.category, .provider)
             XCTAssertEqual(first.logoURL?.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
         }

--- a/MyDataHelpsKitTests/MyDataHelpsClientTests.swift
+++ b/MyDataHelpsKitTests/MyDataHelpsClientTests.swift
@@ -36,9 +36,9 @@ class MyDataHelpsClientTests: XCTestCase {
     
     func testEmbeddableURLs() {
         let sut = MyDataHelpsClient()
-        let participantLinkID = UUID().uuidString
+        let participantLinkID = ParticipantLink.ID(UUID().uuidString)
         let surveyName = UUID().uuidString
-        let taskLinkID = UUID().uuidString
+        let taskLinkID = SurveyTaskLink.ID(UUID().uuidString)
         let languageTag = sut.languageTag
         var url = try? sut.embeddableSurveyURL(surveyName: surveyName, participantLinkIdentifier: participantLinkID).get()
         XCTAssertEqual(url?.absoluteString, "https://mydatahelps.org/mydatahelps/\(participantLinkID)/surveylink/\(surveyName)?lang=\(languageTag)")

--- a/MyDataHelpsKitTests/ScopedIdentifierTests.swift
+++ b/MyDataHelpsKitTests/ScopedIdentifierTests.swift
@@ -21,9 +21,16 @@ class ScopedIdentifierTests: XCTestCase {
         let value: String
     }
     
+    private struct IntModel: Identifiable {
+        typealias ID = ScopedIdentifier<IntModel, Int>
+        let id: ID
+        let value: String
+    }
+    
     private let id100 = ExampleModel.ID("100")
     private let model100 = ExampleModel(id: .init("100"), value: "Value100")
     private let model200 = ExampleModel(id: .init("200"), value: "Value200")
+    private let intModel123 = IntModel(id: .init(123), value: "Value123")
     
     func testHashableEquatable() {
         XCTAssertEqual(id100, id100, "Equatable protocol: identity relation")
@@ -31,6 +38,16 @@ class ScopedIdentifierTests: XCTestCase {
         XCTAssertEqual(id100.hashValue, model100.id.hashValue, "Hashable protocol")
         XCTAssertEqual(model100.value, "Value100", "value")
         XCTAssertNotEqual(model200.id, model100.id, "Equatable: two unequal values")
+        
+        XCTAssertEqual(intModel123.id.value, 123, "Int identifier values")
+    }
+    
+    func testStringRepresentation() {
+        // String interpolation, etc., is important for embedding IDs in URL paths for API endpoints, etc.
+        XCTAssertEqual(id100.description, "100", "String description")
+        XCTAssertEqual(intModel123.id.description, "123", "Int description")
+        XCTAssertEqual("/api/model/\(model200.id)/test", "/api/model/200/test", "String value interpolation")
+        XCTAssertEqual("/api/model/\(intModel123.id)/test", "/api/model/123/test", "Int value interpolation")
     }
     
     func testCodable() throws {

--- a/MyDataHelpsKitTests/ScopedIdentifierTests.swift
+++ b/MyDataHelpsKitTests/ScopedIdentifierTests.swift
@@ -1,0 +1,55 @@
+//
+//  ScopedIdentifierTests.swift
+//  MyDataHelpsKitTests
+//
+//  Created by CareEvolution on 8/17/22.
+//
+
+import XCTest
+@testable import MyDataHelpsKit
+
+class ScopedIdentifierTests: XCTestCase {
+    private struct ExampleModel: Identifiable, Codable {
+        typealias ID = ScopedIdentifier<ExampleModel, String>
+        
+        let id: ID
+        let value: String
+    }
+
+    private struct BasicModel: Decodable {
+        let id: String
+        let value: String
+    }
+    
+    private let id100 = ExampleModel.ID("100")
+    private let model100 = ExampleModel(id: .init("100"), value: "Value100")
+    private let model200 = ExampleModel(id: .init("200"), value: "Value200")
+    
+    func testHashableEquatable() {
+        XCTAssertEqual(id100, id100, "Equatable protocol: identity relation")
+        XCTAssertEqual(id100, model100.id, "Equatable protocol: two equal values")
+        XCTAssertEqual(id100.hashValue, model100.id.hashValue, "Hashable protocol")
+        XCTAssertEqual(model100.value, "Value100", "value")
+        XCTAssertNotEqual(model200.id, model100.id, "Equatable: two unequal values")
+    }
+    
+    func testCodable() throws {
+        let json = """
+{
+    "id": "100",
+    "value": "100Decoded"
+}
+""".data(using: .utf8)!
+        
+        let decoded100 = try JSONDecoder.myDataHelpsDecoder.decode(ExampleModel.self, from: json)
+        XCTAssertEqual(decoded100.id, id100, "ScopedIdentifier automatically decodes")
+        XCTAssertEqual(decoded100.value, "100Decoded", "doesn't interfere with decoding other model properties")
+        
+        let data = try JSONEncoder.myDataHelpsEncoder.encode(model200)
+        
+        // BasicModel has same structure but doesn't use ScopedIdentifier. Encoding/decoding should work identically.
+        let decodedCopy = try JSONDecoder.myDataHelpsDecoder.decode(BasicModel.self, from: data)
+        XCTAssertEqual(decodedCopy.id, model200.id.value, "Encodes id correctly")
+        XCTAssertEqual(decodedCopy.value, model200.value, "Encodes value correctly")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Based on your preferred installation process or dependency manager, choose from 
 Add MyDataHelpsKit as a dependency to your Package.swift file. For more information, see the [Swift Package Manager documentation](https://github.com/apple/swift-package-manager/tree/master/Documentation).
 
 ```swift
-.package(url: "https://github.com/CareEvolution/MyDataHelpsKit-iOS", from: "1.0.0")
+.package(url: "https://github.com/CareEvolution/MyDataHelpsKit-iOS", from: "1.2.0")
 ```
 
 Or in your Xcode project, go to File > Swift Packages > Add Package Dependency and enter `https://github.com/CareEvolution/MyDataHelpsKit-iOS`.

--- a/example/MyDataHelpsKit-Example.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit-Example.xcscheme
+++ b/example/MyDataHelpsKit-Example.xcodeproj/xcshareddata/xcschemes/MyDataHelpsKit-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveySelection.swift
+++ b/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveySelection.swift
@@ -10,24 +10,24 @@ import MyDataHelpsKit
 
 struct EmbeddableSurveySelection: Identifiable {
     let survey: EmbeddableSurveyID
-    let participantLinkIdentifier: String
+    let participantLinkIdentifier: ParticipantLink.ID
     
     var id: String {
         switch survey {
         case let .surveyName(name): return name
-        case let .taskLinkIdentifier(name): return name
+        case let .taskLinkIdentifier(id): return id.value
         }
     }
 }
 
 enum EmbeddableSurveyID: Identifiable {
     case surveyName(String)
-    case taskLinkIdentifier(String)
+    case taskLinkIdentifier(SurveyTaskLink.ID)
     
     var id: String {
         switch self {
         case let .surveyName(name): return name
-        case let .taskLinkIdentifier(name): return name
+        case let .taskLinkIdentifier(id): return id.value
         }
     }
 }

--- a/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveyViewRepresentable.swift
+++ b/example/MyDataHelpsKit-Example/Embeddables/EmbeddableSurveyViewRepresentable.swift
@@ -53,7 +53,7 @@ struct EmbeddableSurveyViewRepresentable_Previews: PreviewProvider {
         @State var errorModel: ErrorView.Model? = nil
         
         var body: some View {
-            EmbeddableSurveyViewRepresentable(model: .init(survey: .surveyName(""), participantLinkIdentifier: ""), presentation: $selection, error: $surveyError)
+            EmbeddableSurveyViewRepresentable(model: .init(survey: .surveyName(""), participantLinkIdentifier: .init("")), presentation: $selection, error: $surveyError)
                 .alert(item: $errorModel) {
                     Alert(title: Text($0.errorDescription))
                 }

--- a/example/MyDataHelpsKit-Example/PagedView/DeviceDataPointView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/DeviceDataPointView.swift
@@ -50,7 +50,7 @@ struct DeviceDataPointView: View {
 struct DeviceDataPointView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            DeviceDataPointView(model: .init(session: ParticipantSessionPreview(), namespace: .project, id: "1", identifier: "1", type: "HeartRate", value: "62", units: nil, source: .init(identifier: "", properties: [:]), startDate: Date(), observationDate: Date()))
+            DeviceDataPointView(model: .init(session: ParticipantSessionPreview(), namespace: .project, id: .init("1"), identifier: "1", type: "HeartRate", value: "62", units: nil, source: .init(identifier: "", properties: [:]), startDate: Date(), observationDate: Date()))
         }
     }
 }

--- a/example/MyDataHelpsKit-Example/PagedView/DeviceDataSource.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/DeviceDataSource.swift
@@ -12,7 +12,7 @@ class DeviceDataSource: PagedModelSource {
     struct ItemModel: Identifiable {
         let session: ParticipantSessionType
         let namespace: DeviceDataNamespace
-        let id: String
+        let id: DeviceDataPoint.ID
         let identifier: String
         let type: String
         let value: String

--- a/example/MyDataHelpsKit-Example/PagedView/NotificationHistoryView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/NotificationHistoryView.swift
@@ -18,7 +18,7 @@ struct NotificationHistoryView: View {
     }
     
     struct Model: Identifiable {
-        let id: String
+        let id: NotificationHistoryModel.ID
         let identifier: String
         let sentDate: Date
         let statusCode: NotificationSendStatusCode
@@ -77,7 +77,7 @@ extension NotificationHistoryView.Model {
 
 struct NotificationHistoryView_Previews: PreviewProvider {
     static var previews: some View {
-        NotificationHistoryView(model: .init(id: "1", identifier: "NOTIFICATION_A", sentDate: Date(), statusCode: .succeeded, content: "Title Text"))
+        NotificationHistoryView(model: .init(id: .init("n1"), identifier: "NOTIFICATION_A", sentDate: Date(), statusCode: .succeeded, content: "Title Text"))
             .padding()
     }
 }

--- a/example/MyDataHelpsKit-Example/PagedView/PagedView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/PagedView.swift
@@ -54,7 +54,7 @@ struct PagedView_Previews: PreviewProvider {
             items
         }
         let items: [PreviewListItem]
-        let nextPageID: String? = nil
+        let nextPageID: ScopedIdentifier<PreviewListPage, String>? = nil
     }
     
     class PreviewSource: PagedModelSource {

--- a/example/MyDataHelpsKit-Example/PagedView/PagedViewModel.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/PagedViewModel.swift
@@ -11,7 +11,7 @@ import MyDataHelpsKit
 protocol PageModelType {
     associatedtype ItemType: Identifiable
     func pageItems(session: ParticipantSessionType) -> [ItemType]
-    var nextPageID: String? { get }
+    var nextPageID: ScopedIdentifier<Self, String>? { get }
 }
 
 protocol PagedModelSource {

--- a/example/MyDataHelpsKit-Example/PagedView/SurveyAnswerView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/SurveyAnswerView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import MyDataHelpsKit
 
 struct SurveyAnswerView: View {
-    static func pageView(session: ParticipantSessionType, surveyID: String?) -> PagedView<SurveyAnswersSource, SurveyAnswerView> {
+    static func pageView(session: ParticipantSessionType, surveyID: Survey.ID?) -> PagedView<SurveyAnswersSource, SurveyAnswerView> {
         /// EXERCISE: Add parameters to this `SurveyAnswersQuery` to further customize filtering.
         let query = SurveyAnswersQuery(surveyID: surveyID)
         let source = SurveyAnswersSource(session: session, query: query)
@@ -20,14 +20,14 @@ struct SurveyAnswerView: View {
     
     class Model: Identifiable, ObservableObject {
         let session: ParticipantSessionType
-        let id: String
-        let surveyResultID: String
+        let id: SurveyAnswer.ID
+        let surveyResultID: SurveyResult.ID
         let value: String
         let date: Date?
         let surveyDisplayName: String
         @Published var deletionState: Result<Void, MyDataHelpsError>? = nil
         
-        init(session: ParticipantSessionType, id: String, surveyResultID: String, value: String, date: Date?, surveyDisplayName: String, deletionState: Result<Void, MyDataHelpsError>? = nil) {
+        init(session: ParticipantSessionType, id: SurveyAnswer.ID, surveyResultID: SurveyResult.ID, value: String, date: Date?, surveyDisplayName: String, deletionState: Result<Void, MyDataHelpsError>? = nil) {
             self.session = session
             self.id = id
             self.surveyResultID = surveyResultID
@@ -49,7 +49,7 @@ struct SurveyAnswerView: View {
         
         func delete() {
             guard deletionState == nil else { return }
-            session.deleteSurveyResult(surveyResultID: surveyResultID) { [weak self] in
+            session.deleteSurveyResult(surveyResultID) { [weak self] in
                 self?.deletionState = $0
             }
         }
@@ -92,11 +92,11 @@ struct SurveyAnswerView: View {
 struct SurveyAnswerView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            SurveyAnswerView(model: .init(session: ParticipantSessionPreview(), id: "1", surveyResultID: "1", value: "Answer Value", date: Date(), surveyDisplayName: "Survey Name", deletionState: nil))
+            SurveyAnswerView(model: .init(session: ParticipantSessionPreview(), id: .init("sa1"), surveyResultID: .init("sr1"), value: "Answer Value", date: Date(), surveyDisplayName: "Survey Name", deletionState: nil))
                 .padding()
-            SurveyAnswerView(model: .init(session: ParticipantSessionPreview(), id: "1", surveyResultID: "1", value: "Answer Value", date: Date(), surveyDisplayName: "Survey Name", deletionState: .success(())))
+            SurveyAnswerView(model: .init(session: ParticipantSessionPreview(), id: .init("sa1"), surveyResultID: .init("sr1"), value: "Answer Value", date: Date(), surveyDisplayName: "Survey Name", deletionState: .success(())))
                 .padding()
-            SurveyAnswerView(model: .init(session: ParticipantSessionPreview(), id: "1", surveyResultID: "1", value: "Answer Value", date: Date(), surveyDisplayName: "Survey Name", deletionState: .failure(.unknown(nil))))
+            SurveyAnswerView(model: .init(session: ParticipantSessionPreview(), id: .init("sa1"), surveyResultID: .init("sr1"), value: "Answer Value", date: Date(), surveyDisplayName: "Survey Name", deletionState: .failure(.unknown(nil))))
                 .padding()
         }
     }

--- a/example/MyDataHelpsKit-Example/PagedView/SurveyTaskView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/SurveyTaskView.swift
@@ -20,8 +20,8 @@ struct SurveyTaskView: View {
     
     struct Model: Identifiable {
         let session: ParticipantSessionType
-        let id: String
-        let surveyID: String
+        let id: SurveyTask.ID
+        let surveyID: Survey.ID
         let surveyDisplayName: String
         let dueDate: Date?
         let hasSavedProgress: Bool
@@ -134,8 +134,8 @@ struct SurveyTaskView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             VStack {
-                ContainerView(model: .init(session: ParticipantSessionPreview(), id: "1", surveyID: "1", surveyDisplayName: "Preview Survey", dueDate: Date(), hasSavedProgress: true, status: .incomplete, surveyName: "name", linkIdentifier: nil), participantLinkIdentifier: nil)
-                ContainerView(model: .init(session: ParticipantSessionPreview(), id: "1", surveyID: "1", surveyDisplayName: "Preview Survey", dueDate: Date(), hasSavedProgress: true, status: .complete, surveyName: "name", linkIdentifier: nil), participantLinkIdentifier: nil)
+                ContainerView(model: .init(session: ParticipantSessionPreview(), id: .init("t1"), surveyID: .init("s1"), surveyDisplayName: "Preview Survey", dueDate: Date(), hasSavedProgress: true, status: .incomplete, surveyName: "name", linkIdentifier: nil), participantLinkIdentifier: nil)
+                ContainerView(model: .init(session: ParticipantSessionPreview(), id: .init("t1"), surveyID: .init("s1"), surveyDisplayName: "Preview Survey", dueDate: Date(), hasSavedProgress: true, status: .complete, surveyName: "name", linkIdentifier: nil), participantLinkIdentifier: nil)
             }
         }
     }

--- a/example/MyDataHelpsKit-Example/PagedView/SurveyTaskView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/SurveyTaskView.swift
@@ -27,11 +27,11 @@ struct SurveyTaskView: View {
         let hasSavedProgress: Bool
         let status: SurveyTaskStatus
         let surveyName: String
-        let linkIdentifier: String?
+        let linkIdentifier: SurveyTaskLink.ID?
     }
     
     let model: Model
-    let participantLinkIdentifier: String?
+    let participantLinkIdentifier: ParticipantLink.ID?
     @State var showingAnswers = false
     @State var embeddableSurveySelection: Binding<EmbeddableSurveySelection?>
     
@@ -123,7 +123,7 @@ extension SurveyTaskView.Model {
 struct SurveyTaskView_Previews: PreviewProvider {
     struct ContainerView: View {
         let model: SurveyTaskView.Model
-        let participantLinkIdentifier: String?
+        let participantLinkIdentifier: ParticipantLink.ID?
         @State var embeddableSurvey: EmbeddableSurveySelection? = nil
         var body: some View {
             SurveyTaskView(model: model, participantLinkIdentifier: participantLinkIdentifier, embeddableSurveySelection: $embeddableSurvey)

--- a/example/MyDataHelpsKit-Example/ProviderConnections/ExternalAccountsListView.swift
+++ b/example/MyDataHelpsKit-Example/ProviderConnections/ExternalAccountsListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import MyDataHelpsKit
 
-extension ExternalAccount: Identifiable {
+extension ExternalAccount {
     var isRefreshable: Bool {
         status != .fetchingData
     }

--- a/example/MyDataHelpsKit-Example/ProviderConnections/ProvidersListView.swift
+++ b/example/MyDataHelpsKit-Example/ProviderConnections/ProvidersListView.swift
@@ -8,11 +8,8 @@
 import SwiftUI
 import MyDataHelpsKit
 
-extension ExternalAccountProvider: Identifiable {
-}
-
 extension ExternalAccountAuthorization: Identifiable {
-    public var id: Int { provider.id }
+    public var id: ExternalAccountProvider.ID { provider.id }
 }
 
 class ProvidersListViewModel: ObservableObject {

--- a/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantInfoView.swift
@@ -10,7 +10,7 @@ import MyDataHelpsKit
 
 struct ParticipantInfoViewModel {
     let name: String
-    let linkIdentifier: String?
+    let linkIdentifier: ParticipantLink.ID?
     let email: String?
     let phone: String?
     let enrollmentDate: Date?

--- a/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
@@ -14,7 +14,7 @@ protocol ParticipantSessionType {
     func queryDeviceData(_ query: DeviceDataQuery, completion: @escaping (Result<DeviceDataResultPage, MyDataHelpsError>) -> Void)
     func querySurveyTasks(_ query: SurveyTaskQuery, completion: @escaping (Result<SurveyTaskResultPage, MyDataHelpsError>) -> Void)
     func querySurveyAnswers(_ query: SurveyAnswersQuery, completion: @escaping (Result<SurveyAnswersPage, MyDataHelpsError>) -> Void)
-    func deleteSurveyResult(surveyResultID: String, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void)
+    func deleteSurveyResult(_ surveyResultID: SurveyResult.ID, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void)
     func queryNotifications(_ query: NotificationHistoryQuery, completion: @escaping (Result<NotificationHistoryPage, MyDataHelpsError>) -> Void)
     func persistDeviceData(_ dataPoints: [DeviceDataPointPersistModel], completion: @escaping (Result<Void, MyDataHelpsError>) -> Void)
     func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<[ExternalAccountProvider], MyDataHelpsError>) -> Void)
@@ -55,7 +55,7 @@ class ParticipantSessionPreview: ParticipantSessionType {
     func querySurveyAnswers(_ query: SurveyAnswersQuery, completion: @escaping (Result<SurveyAnswersPage, MyDataHelpsError>) -> Void) {
     }
     
-    func deleteSurveyResult(surveyResultID: String, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void) {
+    func deleteSurveyResult(_ surveyResultID: SurveyResult.ID, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void) {
         completion(.success(()))
     }
     


### PR DESCRIPTION
## Overview

See #28. This PR will merge into the "v2" branch, to collect multiple breaking changes before the 2.0.0 release.

Implements `ScopedIdentifier`, a generic type that allows ID values for all of the various model structs in this SDK to have their own distinct data type instead of bare String or Int values. This prevents bugs such as using `surveyID` instead of `surveyResultID` in the `deleteSurveyResponse` API, which previously would only be a bug at runtime, not caught by the compiler, and easy to mistakenly implement via typos, copy-paste, etc.

This PR touches a lot of files, but essentially it just introduces one new type and updates a lot of variables to use the new type, along with documentation updates. For reviewing, I'd recommend starting with ScopedIdentifier.swift and its unit tests, and then review all the other changes which are just usages of ScopedIdentifier. Mistakes or bugs to watch for in code review would be (ironically) using the wrong type of ScopedIdentifier for a given variable, typos in documentation, etc.

If you open the workspace in Xcode, you can hack around in the example app to get a feel for how these work in the editor, how code completion works, how the compiler prevents using the wrong identifier type (survey tasks/answers have multiple properties that are ID types so that's a good area to mess around in).

General categories of identifiers affected here:

- Auto-generated database primary keys for model objects: e.g. DeviceDataPoint.id
- pageID values for paged query results: these are opaque values generated by the server, anchor points for a specific batch of paged query results.
- Foreign key IDs with no actual instances of the associated model: e.g. SurveyResult.ID. For these, the ScopedIdentifier needs some sort of type name to refer to, so I created empty wrapper structs (which we could later expand with real properties and allow creating instances, if we implement APIs that can use them).
- Miscellaneous concepts, such as participant link identifiers
- Natural keys and user-entered identifiers that MyDataHelps doesn't directly control, e.g. participantIdentifier/secondaryIdentifier, device data point identifier, notification library identifier, survey names, etc. I decided _not_ to implement these as ScopedIdentifiers. Would appreciate feedback on this decision.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated.

No concern here. No new network or I/O interactions implemented, and improves type safety of existing code.

## Checklist

- [X] All public symbols are documented using Swift Markup comments.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
