### PR TITLE
Make DeviceDataPointPersistModel.identifier optional

### DIFF
--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -139,8 +139,8 @@ public struct DeviceDataPoint: Decodable {
 
 /// Describes a device data point to create or update.
 public struct DeviceDataPointPersistModel: Encodable {
-    /// String used to name a device data point. Natural Key property.
-    public let identifier: String
+    /// String used to name a device data point. Optional. Natural Key property.
+    public let identifier: String?
     /// The general category this device data point belongs in, or what the device data represents. Natural Key property.
     public let type: String
     /// The value of the recorded data point.
@@ -158,7 +158,7 @@ public struct DeviceDataPointPersistModel: Encodable {
     
     /// Initializes an object describing device data point to create or update.
     /// - Parameters:
-    ///   - identifier: String used to name a device data point. Natural Key property.
+    ///   - identifier: String used to name a device data point. Optional. Natural Key property.
     ///   - type: The general category this device data point belongs in, or what the device data represents. Natural Key property.
     ///   - value: The value of the recorded data point.
     ///   - units: The units, if any, that the data was recorded in.
@@ -166,7 +166,7 @@ public struct DeviceDataPointPersistModel: Encodable {
     ///   - source: Identifying information about the device which recorded the data point.
     ///   - startDate: The date at which this device data point began being recorded (for data that is recorded over time). Natural Key property.
     ///   - observationDate: The date at which this device data point was completely recorded. Natural Key property.
-    public init(identifier: String, type: String, value: String, units: String?, properties: [String : String], source: DeviceDataPointSource?, startDate: Date?, observationDate: Date?) {
+    public init(identifier: String?, type: String, value: String, units: String?, properties: [String : String], source: DeviceDataPointSource?, startDate: Date?, observationDate: Date?) {
         self.identifier = identifier
         self.type = type
         self.value = value

--- a/example/MyDataHelpsKit-Example/PagedView/DeviceDataSource.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/DeviceDataSource.swift
@@ -13,7 +13,7 @@ class DeviceDataSource: PagedModelSource {
         let session: ParticipantSessionType
         let namespace: DeviceDataNamespace
         let id: String
-        let identifier: String
+        let identifier: String?
         let type: String
         let value: String
         let units: String?
@@ -56,7 +56,7 @@ extension DeviceDataSource.ItemModel {
         self.session = session
         self.namespace = dataPoint.namespace
         self.id = dataPoint.id
-        self.identifier = dataPoint.identifier ?? ""
+        self.identifier = dataPoint.identifier
         self.type = dataPoint.type
         self.value = dataPoint.value
         self.units = dataPoint.units

--- a/example/MyDataHelpsKit-Example/PersistDeviceDataView.swift
+++ b/example/MyDataHelpsKit-Example/PersistDeviceDataView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 import MyDataHelpsKit
 
 class PersistDeviceDataViewModel: ObservableObject {
+    @Published var identifier = ""
     @Published var type = ""
     @Published var value = ""
     
     let session: ParticipantSessionType
     let isNew: Bool
-    let identifier: String
     let units: String?
     let source: DeviceDataPointSource?
     let startDate: Date?
@@ -24,7 +24,6 @@ class PersistDeviceDataViewModel: ObservableObject {
     init(session: ParticipantSessionType) {
         self.session = session
         self.isNew = true
-        self.identifier = UUID().uuidString
         self.units = nil
         self.source = .init(identifier: UUID().uuidString, properties: [:])
         self.startDate = nil
@@ -34,7 +33,7 @@ class PersistDeviceDataViewModel: ObservableObject {
     init(existing model: DeviceDataSource.ItemModel) {
         self.session = model.session
         self.isNew = false
-        self.identifier = model.identifier
+        self.identifier = model.identifier ?? ""
         self.type = model.type
         self.value = model.value
         self.units = model.units
@@ -44,7 +43,7 @@ class PersistDeviceDataViewModel: ObservableObject {
     }
     
     var persistModel: DeviceDataPointPersistModel {
-        .init(identifier: identifier, type: type, value: value, units: units, properties: [:], source: source, startDate: startDate, observationDate: observationDate)
+        .init(identifier: identifier.isEmpty ? nil : identifier, type: type, value: value, units: units, properties: [:], source: source, startDate: startDate, observationDate: observationDate)
     }
 }
 
@@ -55,6 +54,9 @@ struct PersistDeviceDataView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
+            Text("Identifier:")
+            TextField("Optional", text: $model.identifier)
+                .padding(.bottom, 20)
             Text("Type:")
             TextField("Type", text: $model.type)
                 .padding(.bottom, 20)


### PR DESCRIPTION
## Overview

See #37. Merging into branch "v2" to collect breaking changes for release 2.0.0.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated.

## Checklist

- [X] All public symbols are documented using Swift Markup comments.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
