### PR TITLE
Update/merge project APIs into v2 branch

### DIFF
--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -11,11 +11,11 @@
 		AC02E68425FA7FCD008A46E4 /* SurveyTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E68325FA7FCD008A46E4 /* SurveyTasks.swift */; };
 		AC02E68825FA8056008A46E4 /* SurveyTaskQueryResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E68725FA8056008A46E4 /* SurveyTaskQueryResource.swift */; };
 		AC02E69C25FAA979008A46E4 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E69B25FAA979008A46E4 /* Diagnostics.swift */; };
-		AC2DAB1028A6CFE00023035E /* ScopedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */; };
-		AC2DAB3528AD16D90023035E /* ScopedIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */; };
 		AC0D4E6B28A55E4300FE145B /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0D4E6A28A55E4300FE145B /* Project.swift */; };
 		AC2DAB0628A566040023035E /* ProjectResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0528A566040023035E /* ProjectResource.swift */; };
 		AC2DAB0E28A57BF70023035E /* ProjectModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */; };
+		AC2DAB1028A6CFE00023035E /* ScopedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */; };
+		AC2DAB3528AD16D90023035E /* ScopedIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */; };
 		AC77B4BE25E8495C00427294 /* MyDataHelpsKit.h in Headers */ = {isa = PBXBuildFile; fileRef = AC77B4BC25E8495C00427294 /* MyDataHelpsKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC77B50125E8502000427294 /* MyDataHelpsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC77B50025E8502000427294 /* MyDataHelpsClient.swift */; };
 		AC77B50425E8523500427294 /* ParticipantSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC77B50325E8523500427294 /* ParticipantSession.swift */; };
@@ -63,11 +63,11 @@
 		AC02E68325FA7FCD008A46E4 /* SurveyTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyTasks.swift; sourceTree = "<group>"; };
 		AC02E68725FA8056008A46E4 /* SurveyTaskQueryResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyTaskQueryResource.swift; sourceTree = "<group>"; };
 		AC02E69B25FAA979008A46E4 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
-		AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifier.swift; sourceTree = "<group>"; };
-		AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifierTests.swift; sourceTree = "<group>"; };
 		AC0D4E6A28A55E4300FE145B /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		AC2DAB0528A566040023035E /* ProjectResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectResource.swift; sourceTree = "<group>"; };
 		AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectModelTests.swift; sourceTree = "<group>"; };
+		AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifier.swift; sourceTree = "<group>"; };
+		AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifierTests.swift; sourceTree = "<group>"; };
 		AC77B4B925E8495C00427294 /* MyDataHelpsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MyDataHelpsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC77B4BC25E8495C00427294 /* MyDataHelpsKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyDataHelpsKit.h; sourceTree = "<group>"; };
 		AC77B4BD25E8495C00427294 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -214,9 +214,9 @@
 				ACEAF44D26D683F7002F79AB /* ExternalAccountsTests.swift */,
 				AC83ABDD25F131DA00A668E4 /* Info.plist */,
 				AC9DC9BF260A876F00C5D9E4 /* MyDataHelpsClientTests.swift */,
+				AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */,
 				AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */,
 				AC83ABDB25F131DA00A668E4 /* URLRequestsTests.swift */,
-				AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */,
 			);
 			path = MyDataHelpsKitTests;
 			sourceTree = "<group>";

--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		AC02E69C25FAA979008A46E4 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02E69B25FAA979008A46E4 /* Diagnostics.swift */; };
 		AC2DAB1028A6CFE00023035E /* ScopedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */; };
 		AC2DAB3528AD16D90023035E /* ScopedIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */; };
+		AC0D4E6B28A55E4300FE145B /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0D4E6A28A55E4300FE145B /* Project.swift */; };
+		AC2DAB0628A566040023035E /* ProjectResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0528A566040023035E /* ProjectResource.swift */; };
+		AC2DAB0E28A57BF70023035E /* ProjectModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */; };
 		AC77B4BE25E8495C00427294 /* MyDataHelpsKit.h in Headers */ = {isa = PBXBuildFile; fileRef = AC77B4BC25E8495C00427294 /* MyDataHelpsKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC77B50125E8502000427294 /* MyDataHelpsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC77B50025E8502000427294 /* MyDataHelpsClient.swift */; };
 		AC77B50425E8523500427294 /* ParticipantSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC77B50325E8523500427294 /* ParticipantSession.swift */; };
@@ -62,6 +65,9 @@
 		AC02E69B25FAA979008A46E4 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
 		AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifier.swift; sourceTree = "<group>"; };
 		AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedIdentifierTests.swift; sourceTree = "<group>"; };
+		AC0D4E6A28A55E4300FE145B /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		AC2DAB0528A566040023035E /* ProjectResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectResource.swift; sourceTree = "<group>"; };
+		AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectModelTests.swift; sourceTree = "<group>"; };
 		AC77B4B925E8495C00427294 /* MyDataHelpsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MyDataHelpsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC77B4BC25E8495C00427294 /* MyDataHelpsKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyDataHelpsKit.h; sourceTree = "<group>"; };
 		AC77B4BD25E8495C00427294 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -164,6 +170,7 @@
 				AC9DC9B52609064800C5D9E4 /* NotificationHistory.swift */,
 				AC83ABCC25E991E300A668E4 /* PagedQuery.swift */,
 				AC77B50C25E854E600427294 /* ParticipantInfo.swift */,
+				AC0D4E6A28A55E4300FE145B /* Project.swift */,
 				AC2DAB0F28A6CFE00023035E /* ScopedIdentifier.swift */,
 				AC9DC99F26052AEA00C5D9E4 /* SurveyAnswers.swift */,
 				AC02E68325FA7FCD008A46E4 /* SurveyTasks.swift */,
@@ -192,6 +199,7 @@
 				AC9DC9B92609198700C5D9E4 /* NotificationHistoryQueryResource.swift */,
 				AC77B51425E8576A00427294 /* ParticipantResource.swift */,
 				AC83ABBC25E885D700A668E4 /* PersistDeviceDataResource.swift */,
+				AC2DAB0528A566040023035E /* ProjectResource.swift */,
 				AC9DC9A32605359300C5D9E4 /* SurveyAnswersQueryResource.swift */,
 				AC02E68725FA8056008A46E4 /* SurveyTaskQueryResource.swift */,
 				AC77B51925E857A900427294 /* URLRequests.swift */,
@@ -208,6 +216,7 @@
 				AC9DC9BF260A876F00C5D9E4 /* MyDataHelpsClientTests.swift */,
 				AC2DAB3428AD16D90023035E /* ScopedIdentifierTests.swift */,
 				AC83ABDB25F131DA00A668E4 /* URLRequestsTests.swift */,
+				AC2DAB0D28A57BF70023035E /* ProjectModelTests.swift */,
 			);
 			path = MyDataHelpsKitTests;
 			sourceTree = "<group>";
@@ -365,6 +374,7 @@
 				ACA1A86926D5442800CBD7EA /* ExternalAccountProvidersQueryResource.swift in Sources */,
 				AC9DC9AA2605408600C5D9E4 /* DeleteSurveyResultResource.swift in Sources */,
 				AC77B50425E8523500427294 /* ParticipantSession.swift in Sources */,
+				AC2DAB0628A566040023035E /* ProjectResource.swift in Sources */,
 				AC83ABCD25E991E300A668E4 /* PagedQuery.swift in Sources */,
 				AC77B51025E856D000427294 /* MyDataHelpsError.swift in Sources */,
 				AC77B51A25E857A900427294 /* URLRequests.swift in Sources */,
@@ -375,6 +385,7 @@
 				AC77B50125E8502000427294 /* MyDataHelpsClient.swift in Sources */,
 				ACEAF45926DD7E76002F79AB /* ConnectExternalAccountResource.swift in Sources */,
 				AC2DAB1028A6CFE00023035E /* ScopedIdentifier.swift in Sources */,
+				AC0D4E6B28A55E4300FE145B /* Project.swift in Sources */,
 				AC83ABB925E867E100A668E4 /* DeviceDataQueryResource.swift in Sources */,
 				AC83ABB125E85BB900A668E4 /* GetParticipantInfoResource.swift in Sources */,
 				AC77B50925E8535B00427294 /* ParticipantAccessToken.swift in Sources */,
@@ -401,6 +412,7 @@
 				AC9DC9C0260A876F00C5D9E4 /* MyDataHelpsClientTests.swift in Sources */,
 				ACBF66C627CFE18800BC6945 /* APIRateLimitTests.swift in Sources */,
 				ACEAF44E26D683F7002F79AB /* ExternalAccountsTests.swift in Sources */,
+				AC2DAB0E28A57BF70023035E /* ProjectModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MyDataHelpsKit.xcodeproj/project.pbxproj
+++ b/MyDataHelpsKit.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		ACC2EB9326124D3F0080A3B5 /* Update SDKVersion and podspec */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputFileListPaths = (
@@ -358,7 +358,7 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "# Update SDKVersion.swift constant\n\necho \"// Automatically generated\\nlet MyDataHelpsKitVersion = \\\"${MARKETING_VERSION}\\\"\" > \"${PROJECT_DIR}/MyDataHelpsKit/SDKVersion.swift\"\n\n# Update podspec file\n\npattern='^ *spec.version = .*$'\nsed -I '' -e \"s/${pattern}/  spec.version = '${MARKETING_VERSION}' #auto-generated/g\" MyDataHelpsKit.podspec\n\npattern='^ *spec.swift_version = .*$'\nsed -I '' -e \"s/${pattern}/  spec.swift_version = '${SWIFT_VERSION}' #auto-generated/g\" MyDataHelpsKit.podspec\n\npattern='^ *spec.ios.deployment_target = .*$'\nsed -I '' -e \"s/${pattern}/  spec.ios.deployment_target = '${IPHONEOS_DEPLOYMENT_TARGET}' #auto-generated/g\" MyDataHelpsKit.podspec\n";
 		};

--- a/MyDataHelpsKit/API/ProjectResource.swift
+++ b/MyDataHelpsKit/API/ProjectResource.swift
@@ -1,0 +1,24 @@
+//
+//  ProjectResource.swift
+//  MyDataHelpsKit
+//
+//  Created by CareEvolution on 8/11/22.
+//
+
+import Foundation
+
+struct GetProjectInfoResource: ParticipantResource {
+    typealias ResponseType = ProjectInfo
+    
+    func urlRequest(session: ParticipantSession) throws -> URLRequest {
+        session.authenticatedRequest(.GET, url: session.client.endpoint(path: "api/v1/delegated/project"))
+    }
+}
+
+struct GetProjectDataCollectionSettingsResource: ParticipantResource {
+    typealias ResponseType = ProjectDataCollectionSettings
+    
+    func urlRequest(session: ParticipantSession) throws -> URLRequest {
+        session.authenticatedRequest(.GET, url: session.client.endpoint(path: "api/v1/delegated/datacollectionsettings"))
+    }
+}

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -75,7 +75,7 @@ public struct DeviceDataResultPage: PagedResult, Decodable {
 }
     
 /// Device data is grouped into namespaces, which represent the source frameworks that generate the data. There is also a separate `project` namespace, where projects can persist their own data. The static members of DeviceDataNamespace identify all supported namespace values.
-public struct DeviceDataNamespace: RawRepresentable, Equatable, Decodable {
+public struct DeviceDataNamespace: RawRepresentable, Equatable, Hashable, Decodable {
     public typealias RawValue = String
     
     /// Project-specific device data.

--- a/MyDataHelpsKit/Model/Project.swift
+++ b/MyDataHelpsKit/Model/Project.swift
@@ -8,9 +8,12 @@
 import Foundation
 
 /// Information about the project and its settings.
-public struct ProjectInfo: Decodable {
+public struct ProjectInfo: Identifiable, Decodable {
     /// Unique project identifier.
-    public let id: String
+    public typealias ID = ScopedIdentifier<ProjectInfo, String>
+    
+    /// Unique project identifier.
+    public let id: ID
     /// Project's display name, localized based on participant's language settings.
     public let name: String
     /// Project's display description, localized based on participant's language settings.
@@ -56,7 +59,7 @@ public struct ProjectType: RawRepresentable, Equatable, Decodable {
 }
 
 /// Information about an organization.
-public struct Organization: Decodable {
+public struct Organization: Identifiable, Decodable {
     enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -66,7 +69,10 @@ public struct Organization: Decodable {
     }
     
     /// Unique organization identifier.
-    public let id: String
+    public typealias ID = ScopedIdentifier<Organization, String>
+    
+    /// Unique organization identifier.
+    public let id: ID
     /// Organization name.
     public let name: String
     /// Organization description.

--- a/MyDataHelpsKit/Model/Project.swift
+++ b/MyDataHelpsKit/Model/Project.swift
@@ -1,0 +1,105 @@
+//
+//  Project.swift
+//  MyDataHelpsKit
+//
+//  Created by CareEvolution on 8/11/22.
+//
+
+import Foundation
+
+/// Information about the project and its settings.
+public struct ProjectInfo: Decodable {
+    /// Unique project identifier.
+    public let id: String
+    /// Project's display name, localized based on participant's language settings.
+    public let name: String
+    /// Project's display description, localized based on participant's language settings.
+    public var description: String?
+    /// Code used by participants to enroll in this project, if code enrollment is allowed.
+    public let code: String
+    /// Project type, displayed to participants and used to filter search results.
+    public let type: ProjectType
+    /// Information about the organization for this project.
+    public let organization: Organization
+    /// Contact email for project support displayed to participants.
+    public var supportEmail: String?
+    /// Contact number for project support displayed to participants.
+    public var supportPhone: String?
+    /// A URL where participants can learn more about the project.
+    public var learnMoreURL: URL? {
+        learnMoreLink.flatMap { URL(string: $0) }
+    }
+    /// Site name or title to use as a label for the ``learnMoreURL``, localized based on participant's language settings.
+    public let learnMoreTitle: String?
+    
+    /// The raw decodable value, which may be an empty string or invalid URL.
+    private var learnMoreLink: String?
+}
+
+/// Describes the type of a MyDataHelps project.
+public struct ProjectType: RawRepresentable, Equatable, Decodable {
+    /// The raw value for the project type as stored in MyDataHelps.
+    public let rawValue: String
+    
+    /// A research study.
+    public static let researchStudy = ProjectType(rawValue: "Research Study")
+    /// A wellness program.
+    public static let wellnessProgram = ProjectType(rawValue: "Wellness Program")
+    /// A clinical program.
+    public static let clinicalProgram = ProjectType(rawValue: "Clinical Program")
+    
+    /// Initializes a `ProjectType` with an arbitrary value. Consider using static members such as `ProjectType.researchStudy` instead for known values.
+    /// - Parameter rawValue: The raw value for the project type as stored in MyDataHelps.
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// Information about an organization.
+public struct Organization: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case logoURL = "logoUrl"
+        case color
+    }
+    
+    /// Unique organization identifier.
+    public let id: String
+    /// Organization name.
+    public let name: String
+    /// Organization description.
+    public let description: String?
+    /// Full URL to the organization's logo image.
+    ///
+    /// This URL returns image data, e.g. `image/png`, suitable for decoding directly into a `UIImage` object and presenting in image views. It is a public URL with no authentication required. Image dimensions may vary, so it is recommended to display these images with aspect-fit scaling.
+    public let logoURL: URL
+    /// The organization's brand color, expressed as a hexadecimal string. For example, `"#000000"`.
+    public let color: String
+}
+
+public struct ProjectDataCollectionSettings: Decodable {
+    /// Indicates whether Fitbit data collection is enabled for this project.
+    public let fitbitEnabled: Bool
+    /// Indicates whether Electronic Health Record data collection is enabled for this project.
+    public let ehrEnabled: Bool
+    /// Indicates whether Air Quality data collection is enabled for this project.
+    public let airQualityEnabled: Bool
+    /// Indicates whether Weather data collection is enabled for this project.
+    public let weatherEnabled: Bool
+    /// A collection of device data types that are supported by the current project configuration and can be queried using `ParticipantSession.queryDeviceData`. A participant may not have data available for all data types.
+    public let queryableDeviceDataTypes: Set<QueryableDeviceDataType>
+    /// Date when sensor data collection ended or will end for this participant.
+    ///
+    /// More Info: [Stopping Device Data Collection](https://support.mydatahelps.org/hc/en-us/articles/4404704688915-Defining-End-of-Project-for-Participants#h_01FMARCJ1S5T80A6X4M115E551).
+    public let sensorDataCollectionEndDate: Date?
+}
+
+/// Information about a single device data type that is supported by the current project configuration and can be queried using the Device Data API.
+public struct QueryableDeviceDataType: Decodable, Equatable, Hashable {
+    /// The namespace to use when querying for device data.
+    public let namespace: DeviceDataNamespace
+    /// The type to use when querying for device data.
+    public let type: String
+}

--- a/MyDataHelpsKit/Session/ParticipantSession.swift
+++ b/MyDataHelpsKit/Session/ParticipantSession.swift
@@ -29,12 +29,24 @@ public final class ParticipantSession {
         self.session = client.newURLSession()
     }
     
-    // MARK: Participant info
+    // MARK: Participant and project info
     
     /// Retrieves basic information about the participant.
     /// - Parameter completion: Called when the request is complete, with a `ParticipantInfo` instance on success or an error on failure.
     public func getParticipantInfo(completion: @escaping (Result<ParticipantInfo, MyDataHelpsError>) -> Void) {
         load(resource: GetParticipantInfoResource(), completion: completion)
+    }
+    
+    /// Retrieves general project information.
+    /// - Parameter completion: Called when the request is complete, with a ``ProjectInfo`` instance on success or an error on failure.
+    public func getProjectInfo(completion: @escaping (Result<ProjectInfo, MyDataHelpsError>) -> Void) {
+        load(resource: GetProjectInfoResource(), completion: completion)
+    }
+    
+    /// Retrieves settings related to data collection for the participant and their project.
+    /// - Parameter completion: Called when the request is complete, with a ``ProjectDataCollectionSettings`` instance on success or an error on failure.
+    public func getDataCollectionSettings(completion: @escaping (Result<ProjectDataCollectionSettings, MyDataHelpsError>) -> Void) {
+        load(resource: GetProjectDataCollectionSettingsResource(), completion: completion)
     }
     
     // MARK: Device data
@@ -49,7 +61,7 @@ public final class ParticipantSession {
         load(resource: DeviceDataQueryResource(query: query), completion: completion)
     }
     
-    /// Creats new and/or updates existing device data points. Each device data point is uniquely identified by a combination of its properties, called a natural key, as identified in `DeviceDataPointPersistModel`. Data points are always persisted with the `project` namespace.
+    /// Creates new and/or updates existing device data points. Each device data point is uniquely identified by a combination of its properties, called a natural key, as identified in `DeviceDataPointPersistModel`. Data points are always persisted with the `project` namespace.
     ///
     /// To update an existing device data point, persist one whose natural key properties exactly match the one to be updated. All non-natural key properties will be updated to your persisted point.
     ///

--- a/MyDataHelpsKitTests/ExternalAccountsTests.swift
+++ b/MyDataHelpsKitTests/ExternalAccountsTests.swift
@@ -16,7 +16,8 @@ private let accountsJSON = """
 
 private let providersJSON = """
     [
-        { "id": 1, "name": "MyDataHelps Demo Provider", "category": "Provider", "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png" }
+        { "id": 1, "name": "MyDataHelps Demo Provider", "category": "Provider", "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png" },
+        { "id": 2, "name": "Unknown Category Provider", "category": "NewCategory", "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png" }
     ]
     """.data(using: .utf8)!
 
@@ -35,11 +36,15 @@ class ExternalAccountsTests: XCTestCase {
     
     func testProviderAccountsJSONDecodes() throws {
         let list = try JSONDecoder.myDataHelpsDecoder.decode([ExternalAccountProvider].self, from: providersJSON)
-        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(list.count, 2)
         if let first = list.first {
             XCTAssertEqual(first.id.value, 1)
+            XCTAssertEqual(first.name, "MyDataHelps Demo Provider")
             XCTAssertEqual(first.category, .provider)
             XCTAssertEqual(first.logoURL?.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
+        }
+        if let last = list.last {
+            XCTAssertEqual(last.category, .init(rawValue: "NewCategory"), "Unknown category decodes without error")
         }
     }
 }

--- a/MyDataHelpsKitTests/ProjectModelTests.swift
+++ b/MyDataHelpsKitTests/ProjectModelTests.swift
@@ -1,0 +1,157 @@
+//
+//  ProjectModelTests.swift
+//  MyDataHelpsKitTests
+//
+//  Created by CareEvolution on 8/11/22.
+//
+
+import XCTest
+@testable import MyDataHelpsKit
+
+class ProjectModelTests: XCTestCase {
+    func testDecodeProjectInfoWithAllKeysPresent() throws {
+        let decoder = JSONDecoder.myDataHelpsDecoder
+        
+        let projectID = UUID().uuidString
+        let organizationID = UUID().uuidString
+        let json = """
+{
+    "id": "\(projectID)",
+    "name": "Example Project",
+    "description": "Project description",
+    "code": "ABCDEF",
+    "type": "Research Study",
+    "organization": {
+        "id": "\(organizationID)",
+        "name": "My Organization",
+        "description": "Organization description",
+        "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png",
+        "color": "#0c509b"
+    },
+    "supportEmail": "support@example.com",
+    "supportPhone": "(555) 555-1212",
+    "learnMoreLink": "https://example.com/",
+    "learnMoreTitle": "Learn More"
+}
+""".data(using: .utf8)!
+        
+        let project = try decoder.decode(ProjectInfo.self, from: json)
+        XCTAssertEqual(project.id, projectID)
+        XCTAssertEqual(project.name, "Example Project")
+        XCTAssertEqual(project.description, "Project description")
+        XCTAssertEqual(project.code, "ABCDEF")
+        XCTAssertEqual(project.type, .researchStudy)
+        XCTAssertEqual(project.supportEmail, "support@example.com")
+        XCTAssertEqual(project.supportPhone, "(555) 555-1212")
+        XCTAssertEqual(project.learnMoreURL?.absoluteString, "https://example.com/")
+        XCTAssertEqual(project.learnMoreTitle, "Learn More")
+        
+        XCTAssertEqual(project.organization.id, organizationID)
+        XCTAssertEqual(project.organization.name, "My Organization")
+        XCTAssertEqual(project.organization.description, "Organization description")
+        XCTAssertEqual(project.organization.logoURL.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
+        XCTAssertEqual(project.organization.color, "#0c509b")
+    }
+    
+    func testDecodeProjectInfoWithOptionalValues() throws {
+        let decoder = JSONDecoder.myDataHelpsDecoder
+        
+        let projectID = UUID().uuidString
+        let organizationID = UUID().uuidString
+        let json = """
+{
+    "id": "\(projectID)",
+    "name": "Example Project",
+    "code": "ABCDEF",
+    "type": "Unknown",
+    "organization": {
+        "id": "\(organizationID)",
+        "name": "My Organization",
+        "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png",
+        "color": "#0c509b"
+    }
+}
+""".data(using: .utf8)!
+        
+        let project = try decoder.decode(ProjectInfo.self, from: json)
+        XCTAssertEqual(project.id, projectID)
+        XCTAssertEqual(project.name, "Example Project")
+        XCTAssertNil(project.description, "description is nil")
+        XCTAssertEqual(project.code, "ABCDEF")
+        XCTAssertEqual(project.type.rawValue, "Unknown", "Decodes unknown ProjectType without error")
+        XCTAssertNil(project.supportEmail, "supportEmail is nil")
+        XCTAssertNil(project.supportPhone, "supportPhone is nil")
+        XCTAssertNil(project.learnMoreURL, "learnMoreURL is nil")
+        XCTAssertNil(project.learnMoreTitle, "learnMoreTitle is nil")
+        
+        XCTAssertEqual(project.organization.id, organizationID)
+        XCTAssertEqual(project.organization.name, "My Organization")
+        XCTAssertNil(project.organization.description, "Organization description is nil")
+        XCTAssertEqual(project.organization.logoURL.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
+        XCTAssertEqual(project.organization.color, "#0c509b")
+    }
+    
+    func testDecodeProjectInfoWithEmptyStringURL() throws {
+        let decoder = JSONDecoder.myDataHelpsDecoder
+        
+        let projectID = UUID().uuidString
+        let organizationID = UUID().uuidString
+        let json = """
+{
+    "id": "\(projectID)",
+    "name": "Example Project",
+    "code": "ABCDEF",
+    "type": "Unknown",
+    "organization": {
+        "id": "\(organizationID)",
+        "name": "My Organization",
+        "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png",
+        "color": "#0c509b"
+    },
+    "learnMoreLink": ""
+}
+""".data(using: .utf8)!
+        
+        let project = try decoder.decode(ProjectInfo.self, from: json)
+        XCTAssertNil(project.learnMoreURL)
+    }
+    
+    func testDecodeDataCollectionSettingsWithAllKeysPresent() throws {
+        let decoder = JSONDecoder.myDataHelpsDecoder
+        let json = """
+{
+    "fitbitEnabled": true,
+    "ehrEnabled": false,
+    "airQualityEnabled": true,
+    "weatherEnabled": false,
+    "queryableDeviceDataTypes": [
+        {
+            "namespace": "GoogleFit",
+            "type": "HeartRate"
+        },
+        {
+            "namespace": "AppleHealth",
+            "type": "Steps"
+        }
+    ],
+    "sensorDataCollectionEndDate": "2022-08-11T12:00:00Z"
+}
+""".data(using: .utf8)!
+        
+        let settings = try decoder.decode(ProjectDataCollectionSettings.self, from: json)
+        XCTAssertTrue(settings.fitbitEnabled, "fitbitEnabled")
+        XCTAssertFalse(settings.ehrEnabled, "!ehrEnabled")
+        XCTAssertTrue(settings.airQualityEnabled, "airQualityEnabled")
+        XCTAssertFalse(settings.weatherEnabled, "!weatherEnabled")
+        XCTAssertEqual(settings.queryableDeviceDataTypes.count, 2)
+        XCTAssertTrue(settings.queryableDeviceDataTypes.contains(.init(namespace: .googleFit, type: "HeartRate")), "queryableDeviceDataTypes contains HeartRate")
+        XCTAssertTrue(settings.queryableDeviceDataTypes.contains(.init(namespace: .appleHealth, type: "Steps")), "queryableDeviceDataTypes contains Steps")
+        XCTAssertNotNil(settings.sensorDataCollectionEndDate, "sensorDataCollectionEndDate not nil")
+        
+        if let sensorDataCollectionEndDate = settings.sensorDataCollectionEndDate {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = .init(secondsFromGMT: 0)!
+            XCTAssertTrue(calendar.date(sensorDataCollectionEndDate, matchesComponents: .init(year: 2022, month: 8, day: 11, hour: 12, minute: 0, second: 0)), "sensorDataCollectionEndDate is correct")
+        }
+    }
+}

--- a/MyDataHelpsKitTests/ProjectModelTests.swift
+++ b/MyDataHelpsKitTests/ProjectModelTests.swift
@@ -36,7 +36,7 @@ class ProjectModelTests: XCTestCase {
 """.data(using: .utf8)!
         
         let project = try decoder.decode(ProjectInfo.self, from: json)
-        XCTAssertEqual(project.id, projectID)
+        XCTAssertEqual(project.id.value, projectID)
         XCTAssertEqual(project.name, "Example Project")
         XCTAssertEqual(project.description, "Project description")
         XCTAssertEqual(project.code, "ABCDEF")
@@ -46,7 +46,7 @@ class ProjectModelTests: XCTestCase {
         XCTAssertEqual(project.learnMoreURL?.absoluteString, "https://example.com/")
         XCTAssertEqual(project.learnMoreTitle, "Learn More")
         
-        XCTAssertEqual(project.organization.id, organizationID)
+        XCTAssertEqual(project.organization.id.value, organizationID)
         XCTAssertEqual(project.organization.name, "My Organization")
         XCTAssertEqual(project.organization.description, "Organization description")
         XCTAssertEqual(project.organization.logoURL.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
@@ -74,7 +74,7 @@ class ProjectModelTests: XCTestCase {
 """.data(using: .utf8)!
         
         let project = try decoder.decode(ProjectInfo.self, from: json)
-        XCTAssertEqual(project.id, projectID)
+        XCTAssertEqual(project.id.value, projectID)
         XCTAssertEqual(project.name, "Example Project")
         XCTAssertNil(project.description, "description is nil")
         XCTAssertEqual(project.code, "ABCDEF")
@@ -84,7 +84,7 @@ class ProjectModelTests: XCTestCase {
         XCTAssertNil(project.learnMoreURL, "learnMoreURL is nil")
         XCTAssertNil(project.learnMoreTitle, "learnMoreTitle is nil")
         
-        XCTAssertEqual(project.organization.id, organizationID)
+        XCTAssertEqual(project.organization.id.value, organizationID)
         XCTAssertEqual(project.organization.name, "My Organization")
         XCTAssertNil(project.organization.description, "Organization description is nil")
         XCTAssertEqual(project.organization.logoURL.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")

--- a/example/MyDataHelpsKit-Example.xcodeproj/project.pbxproj
+++ b/example/MyDataHelpsKit-Example.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		27AA30DD26D6946500AC0D2C /* RemoteImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AA30DC26D6946500AC0D2C /* RemoteImageView.swift */; };
+		AC0D4E6D28A560C700FE145B /* ProjectInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0D4E6C28A560C700FE145B /* ProjectInfoView.swift */; };
 		AC44F53E261375EE0065075C /* MyDataHelpsKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC44F53D261375EE0065075C /* MyDataHelpsKit.framework */; };
 		AC44F561261610A10065075C /* PersistDeviceDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC44F560261610A10065075C /* PersistDeviceDataView.swift */; };
 		AC8E0BB626694D830072A9C1 /* EmbeddableSurveySelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E0BB526694D830072A9C1 /* EmbeddableSurveySelection.swift */; };
@@ -42,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		27AA30DC26D6946500AC0D2C /* RemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageView.swift; sourceTree = "<group>"; };
+		AC0D4E6C28A560C700FE145B /* ProjectInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectInfoView.swift; sourceTree = "<group>"; };
 		AC44F53D261375EE0065075C /* MyDataHelpsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MyDataHelpsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC44F54126137CBE0065075C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		AC44F560261610A10065075C /* PersistDeviceDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistDeviceDataView.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				ACCD97E4260E490E00FF7438 /* PagedView */,
 				AC44F560261610A10065075C /* PersistDeviceDataView.swift */,
 				AC9DC9E7260E374F00C5D9E4 /* Preview Content */,
+				AC0D4E6C28A560C700FE145B /* ProjectInfoView.swift */,
 				ACA1A86A26D5452900CBD7EA /* ProviderConnections */,
 				27AA30DC26D6946500AC0D2C /* RemoteImageView.swift */,
 				AC9DC9F5260E37B500C5D9E4 /* Session */,
@@ -273,6 +276,7 @@
 				ACEAF44A26D67C95002F79AB /* ExternalAccountsListView.swift in Sources */,
 				ACCD9801260E6E3000FF7438 /* NotificationHistoryView.swift in Sources */,
 				AC9DCA0D260E3CE700C5D9E4 /* ParticipantModel.swift in Sources */,
+				AC0D4E6D28A560C700FE145B /* ProjectInfoView.swift in Sources */,
 				ACEAF45726D91B9B002F79AB /* ParticipantSessionType.swift in Sources */,
 				ACCD9804260E6F7A00FF7438 /* NotificationHistorySource.swift in Sources */,
 				AC44F561261610A10065075C /* PersistDeviceDataView.swift in Sources */,

--- a/example/MyDataHelpsKit-Example/ProjectInfoView.swift
+++ b/example/MyDataHelpsKit-Example/ProjectInfoView.swift
@@ -1,0 +1,93 @@
+//
+//  ProjectInfoView.swift
+//  MyDataHelpsKit-Example
+//
+//  Created by CareEvolution on 8/11/22.
+//
+
+import SwiftUI
+import MyDataHelpsKit
+
+struct ProjectInfoView: View {
+    let project: ProjectInfo
+    let dataCollectionSettings: ProjectDataCollectionSettings
+    
+    var body: some View {
+        HStack(alignment: .top) {
+            RemoteImageView(url: project.organization.logoURL, placeholderImageName: "providerLogoPlaceholder")
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 45, height: 45)
+            VStack(alignment: .leading) {
+                Text(project.name)
+                    .font(.subheadline)
+                Text(project.organization.name)
+                    .font(.footnote)
+                Text(project.code)
+                    .font(.caption)
+                Text("Queryable data types: \(dataCollectionSettings.queryableDeviceDataTypes.count)")
+                    .font(.caption)
+                if let learnMoreURL = project.learnMoreURL,
+                   let learnMoreTitle = project.learnMoreTitle {
+                    Link(learnMoreTitle, destination: learnMoreURL)
+                        .font(.caption)
+                }
+                
+            }
+        }
+    }
+}
+
+struct ProjectInfoView_Previews: PreviewProvider {
+    private static let projectJSON: Data = """
+{
+    "id": "\(UUID().uuidString)",
+    "name": "Example Project",
+    "description": "Project description",
+    "code": "ABCDEF",
+    "type": "Research Study",
+    "organization": {
+        "id": "\(UUID().uuidString)",
+        "name": "My Organization",
+        "description": "Organization description",
+        "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png",
+        "color": "#0c509b"
+    },
+    "supportEmail": "support@example.com",
+    "supportPhone": "(555) 555-1212",
+    "learnMoreLink": "https://example.com",
+    "learnMoreTitle": "Learn More"
+}
+""".data(using: .utf8)!
+    
+    private static let projectDataCollectionSettingsJSON: Data = """
+{
+    "fitbitEnabled": true,
+    "ehrEnabled": true,
+    "airQualityEnabled": true,
+    "weatherEnabled": true,
+    "queryableDeviceDataTypes": [
+        {
+            "namespace": "GoogleFit",
+            "type": "HeartRate"
+        },
+        {
+            "namespace": "AppleHealth",
+            "type": "Steps"
+        }
+    ],
+    "sensorDataCollectionEndDate": null
+}
+""".data(using: .utf8)!
+    
+    static var project: ProjectInfo {
+        try! JSONDecoder.myDataHelpsDecoder.decode(ProjectInfo.self, from: projectJSON)
+    }
+    
+    static var projectDataCollectionSettings: ProjectDataCollectionSettings {
+        try! JSONDecoder.myDataHelpsDecoder.decode(ProjectDataCollectionSettings.self, from: projectDataCollectionSettingsJSON)
+    }
+    
+    static var previews: some View {
+        ProjectInfoView(project: project, dataCollectionSettings: projectDataCollectionSettings)
+    }
+}

--- a/example/MyDataHelpsKit-Example/ProjectInfoView.swift
+++ b/example/MyDataHelpsKit-Example/ProjectInfoView.swift
@@ -89,5 +89,6 @@ struct ProjectInfoView_Previews: PreviewProvider {
     
     static var previews: some View {
         ProjectInfoView(project: project, dataCollectionSettings: projectDataCollectionSettings)
+            .environmentObject(RemoteImageCache())
     }
 }

--- a/example/MyDataHelpsKit-Example/Session/ParticipantModel.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantModel.swift
@@ -12,6 +12,8 @@ class ParticipantModel: ObservableObject {
     let session: ParticipantSessionType
     
     @Published var info: Result<ParticipantInfoViewModel, MyDataHelpsError>? = nil
+    @Published var project: Result<ProjectInfo, MyDataHelpsError>? = nil
+    @Published var dataCollectionSettings: Result<ProjectDataCollectionSettings, MyDataHelpsError>? = nil
     
     init(session: ParticipantSessionType) {
         self.session = session
@@ -21,6 +23,20 @@ class ParticipantModel: ObservableObject {
         if case .some(.success(_)) = info { return }
         session.getParticipantInfoViewModel { [weak self] result in
             self?.info = result
+        }
+    }
+    
+    func loadProject() {
+        if case .some(.success) = project { return }
+        session.getProjectInfo { [weak self] in
+            self?.project = $0
+        }
+    }
+    
+    func loadDataCollectionSettings() {
+        if case .some(.success) = project { return }
+        session.getDataCollectionSettings { [weak self] in
+            self?.dataCollectionSettings = $0
         }
     }
 }

--- a/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
@@ -11,6 +11,8 @@ import MyDataHelpsKit
 /// Protocol wrapping MyDataHelpsKit.ParticipantSession, to allow substituting stub implementations for SwiftUI Previews.
 protocol ParticipantSessionType {
     func getParticipantInfoViewModel(completion: @escaping (Result<ParticipantInfoViewModel, MyDataHelpsError>) -> Void)
+    func getProjectInfo(completion: @escaping (Result<ProjectInfo, MyDataHelpsError>) -> Void)
+    func getDataCollectionSettings(completion: @escaping (Result<ProjectDataCollectionSettings, MyDataHelpsError>) -> Void)
     func queryDeviceData(_ query: DeviceDataQuery, completion: @escaping (Result<DeviceDataResultPage, MyDataHelpsError>) -> Void)
     func querySurveyTasks(_ query: SurveyTaskQuery, completion: @escaping (Result<SurveyTaskResultPage, MyDataHelpsError>) -> Void)
     func querySurveyAnswers(_ query: SurveyAnswersQuery, completion: @escaping (Result<SurveyAnswersPage, MyDataHelpsError>) -> Void)
@@ -44,6 +46,14 @@ class ParticipantSessionPreview: ParticipantSessionType {
     
     func getParticipantInfoViewModel(completion: @escaping (Result<ParticipantInfoViewModel, MyDataHelpsError>) -> Void) {
         completion(.success(.init(name: "name", linkIdentifier: nil, email: "email", phone: "phone", enrollmentDate: Date(), isUnsubscribedFromEmails: false)))
+    }
+    
+    func getProjectInfo(completion: @escaping (Result<ProjectInfo, MyDataHelpsError>) -> Void) {
+        completion(.success(ProjectInfoView_Previews.project))
+    }
+    
+    func getDataCollectionSettings(completion: @escaping (Result<ProjectDataCollectionSettings, MyDataHelpsError>) -> Void) {
+        completion(.success(ProjectInfoView_Previews.projectDataCollectionSettings))
     }
     
     func queryDeviceData(_ query: DeviceDataQuery, completion: @escaping (Result<DeviceDataResultPage, MyDataHelpsError>) -> Void) {

--- a/example/MyDataHelpsKit-Example/Session/RootMenuView.swift
+++ b/example/MyDataHelpsKit-Example/Session/RootMenuView.swift
@@ -49,6 +49,12 @@ struct RootMenuView: View {
                     .roundRectComponent()
             }
             
+            if case let .some(.success(project)) = participant.project,
+               case let .some(.success(dataCollectionSettings)) = participant.dataCollectionSettings {
+                ProjectInfoView(project: project, dataCollectionSettings: dataCollectionSettings)
+                    .roundRectComponent()
+            }
+            
             /// EXERCISE: Modify the `types` set to filter for different types of HealthKit data used by your project, or add additional optional parameters to the `DeviceDataQuery` to further customize filtering.
             NavigationLink(
                 destination: DeviceDataPointView.pageView(session: participant.session, namespace: .appleHealth, types: Set(["StandHourInterval"]))
@@ -124,6 +130,8 @@ struct RootMenuView: View {
     
     func loadParticipantInfo() {
         participant.loadInfo()
+        participant.loadProject()
+        participant.loadDataCollectionSettings()
     }
 }
 

--- a/example/README.md
+++ b/example/README.md
@@ -16,10 +16,11 @@ Browse the example app source code to see how a real app might use the MyDataHel
 
 The headings below describe the functionality you can find in each subview accessed from the example app's main menu (RootMenuView):
 
-### Participant Info
+### Participant/Project Info
 
 - After entering a valid participant token and proceeding to the main menu, the app immediately loads and displays the ParticipantInfo object via `ParticipantSession.getParticipantInfo`
 - Modify `ParticipantInfoView` to experiment with displaying various ParticipantInfo properties or demographic fields
+- Similarly, project info and data collection settings retrieved via `ParticipantSession.getProjectInfo` and `ParticipantSession.getDataCollectionSettings` are displayed in a `ProjectInfoView`; modify this view to explore the various data available in project info or data settings.
 
 ### Query Survey Tasks
 


### PR DESCRIPTION
## Overview

Project APIs were just merged to `main` (for possible v1.3.0 release) in #40. Type-safe identifiers were separately merged to `v2` for v2.0.0 release in #41.

This PR pulls the Project APIs feature into the `v2` branch, and adds minor changes for type-safe identifier compatibility. Filter by commit in the diff view to see the type-safe identifier updates.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated.

No concern: just syntax changes.

## Checklist

- [X] All public symbols are documented using Swift Markup comments.
- [X] If this feature requires a developer doc update, tag @CareEvolution/api-docs.
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
