### PR TITLE
Paged external account providers query

### DIFF
--- a/MyDataHelpsKit/API/DeviceDataQueryResource.swift
+++ b/MyDataHelpsKit/API/DeviceDataQueryResource.swift
@@ -31,7 +31,7 @@ struct DeviceDataQueryResource: ParticipantResource {
             queryItems.append(.init(name: "modifiedBefore", value: modifiedBefore))
         }
         
-        queryItems.append(.init(name: "limit", value: "\(query.limit)"))
+        queryItems.append(.init(name: "limit", value: String(query.limit)))
         if let pageID = query.pageID {
             queryItems.append(.init(name: "pageID", value: pageID.value))
         }

--- a/MyDataHelpsKit/API/ExternalAccountProvidersQueryResource.swift
+++ b/MyDataHelpsKit/API/ExternalAccountProvidersQueryResource.swift
@@ -8,12 +8,15 @@
 import Foundation
 
 struct ExternalAccountProvidersQueryResource: ParticipantResource {
-    typealias ResponseType = [ExternalAccountProvider]
+    typealias ResponseType = ExternalAccountProvidersResultPage.APIResponse
     
     let query: ExternalAccountProvidersQuery
     
     func urlRequest(session: ParticipantSession) throws -> URLRequest {
-        var queryItems: [URLQueryItem] = []
+        var queryItems: [URLQueryItem] = [
+            .init(name: "pageSize", value: String(query.limit)),
+            .init(name: "pageNumber", value: String(query.pageNumber))
+        ]
         
         if let search = query.search {
             queryItems.append(.init(name: "search", value: search))

--- a/MyDataHelpsKit/API/NotificationHistoryQueryResource.swift
+++ b/MyDataHelpsKit/API/NotificationHistoryQueryResource.swift
@@ -31,7 +31,7 @@ struct NotificationHistoryQueryResource: ParticipantResource {
             queryItems.append(.init(name: "statusCode", value: statusCode.rawValue))
         }
         
-        queryItems.append(.init(name: "limit", value: "\(query.limit)"))
+        queryItems.append(.init(name: "limit", value: String(query.limit)))
         if let pageID = query.pageID {
             queryItems.append(.init(name: "pageID", value: pageID.value))
         }

--- a/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyAnswersQueryResource.swift
@@ -45,7 +45,7 @@ struct SurveyAnswersQueryResource: ParticipantResource {
             queryItems.append(.init(name: "answer", value: answers))
         }
         
-        queryItems.append(.init(name: "limit", value: "\(query.limit)"))
+        queryItems.append(.init(name: "limit", value: String(query.limit)))
         if let pageID = query.pageID {
             queryItems.append(.init(name: "pageID", value: pageID.value))
         }

--- a/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
+++ b/MyDataHelpsKit/API/SurveyTaskQueryResource.swift
@@ -30,7 +30,7 @@ struct SurveyTaskQueryResource: ParticipantResource {
             queryItems.append(.init(name: "sortOrder", value: sortOrder.rawValue))
         }
         
-        queryItems.append(.init(name: "limit", value: "\(query.limit)"))
+        queryItems.append(.init(name: "limit", value: String(query.limit)))
         if let pageID = query.pageID {
             queryItems.append(.init(name: "pageID", value: pageID.value))
         }

--- a/MyDataHelpsKit/Model/DeviceData.swift
+++ b/MyDataHelpsKit/Model/DeviceData.swift
@@ -55,9 +55,9 @@ public struct DeviceDataQuery: PagedQuery {
         self.pageID = pageID
     }
     
-    /// Initializes a new query for a page of results following the given page, with the same filters as the original query.
+    /// Creates a copy of this query for a page of results following the given page, with the same filters as the original query.
     /// - Parameter page: the previous page of results, which should have been produced with this query.
-    /// - Returns: A query for results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
+    /// - Returns: A copy of this query for fetching results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: DeviceDataResultPage) -> DeviceDataQuery? {
         guard let nextPageID = page.nextPageID else { return nil }
         return DeviceDataQuery(namespace: namespace, types: types, observedAfter: observedAfter, observedBefore: observedBefore, modifiedAfter: modifiedAfter, modifiedBefore: modifiedBefore, limit: limit, pageID: nextPageID)

--- a/MyDataHelpsKit/Model/NotificationHistory.swift
+++ b/MyDataHelpsKit/Model/NotificationHistory.swift
@@ -49,9 +49,9 @@ public struct NotificationHistoryQuery: PagedQuery {
         self.pageID = pageID
     }
     
-    /// Initializes a new query for a page of results following the given page, with the same filters as the original query.
+    /// Creates a copy of this query for a page of results following the given page, with the same filters as the original query.
     /// - Parameter page: The previous page of results, which should have been produced with this query.
-    /// - Returns: A query for results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
+    /// - Returns: A copy of this query for fetching results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: NotificationHistoryPage) -> NotificationHistoryQuery? {
         guard let nextPageID = page.nextPageID else { return nil }
         return NotificationHistoryQuery(identifier: identifier, sentAfter: sentAfter, sentBefore: sentBefore, type: type, statusCode: statusCode, limit: limit, pageID: nextPageID)

--- a/MyDataHelpsKit/Model/SurveyAnswers.swift
+++ b/MyDataHelpsKit/Model/SurveyAnswers.swift
@@ -71,9 +71,9 @@ public struct SurveyAnswersQuery: PagedQuery {
         self.pageID = pageID
     }
     
-    /// Initializes a new query for a page of results following the given page, with the same filters as the original query.
+    /// Creates copy of this query for a page of results following the given page, with the same filters as the original query.
     /// - Parameter page: The previous page of results, which should have been produced with this query.
-    /// - Returns: A query for results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
+    /// - Returns: A copy of this query for fetching results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: SurveyAnswersPage) -> SurveyAnswersQuery? {
         guard let nextPageID = page.nextPageID else { return nil }
         return SurveyAnswersQuery(surveyResultID: surveyResultID, surveyID: surveyID, surveyNames: surveyNames, after: after, before: before, insertedAfter: insertedAfter, insertedBefore: insertedBefore, stepIdentifiers: stepIdentifiers, resultIdentifiers: resultIdentifiers, answers: answers, limit: limit, pageID: nextPageID)

--- a/MyDataHelpsKit/Model/SurveyTasks.swift
+++ b/MyDataHelpsKit/Model/SurveyTasks.swift
@@ -77,9 +77,9 @@ public struct SurveyTaskQuery: PagedQuery {
         self.pageID = pageID
     }
     
-    /// Initializes a new query for a page of results following the given page, with the same filters as the original query.
+    /// Creates a copy of this query for a page of results following the given page, with the same filters as the original query.
     /// - Parameter page: The previous page of results, which should have been produced with this query.
-    /// - Returns: A query for results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
+    /// - Returns: A copy of this query for fetching results following `page`, if page has a `nextPageID`. If there are no additional pages of results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: SurveyTaskResultPage) -> SurveyTaskQuery? {
         guard let nextPageID = page.nextPageID else { return nil }
         return SurveyTaskQuery(statuses: statuses, surveyID: surveyID, surveyNames: surveyNames, linkIdentifier: linkIdentifier, sortOrder: sortOrder, limit: limit, pageID: nextPageID)

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
@@ -21,7 +21,7 @@ public extension ParticipantSession {
     
     /// Initiates a new connected external account. Grants access to a secure OAuth connection to the specified external account provider, where the participant can provide their provider credentials and authorize MyDataHelps to retrieve data from the account.
     ///
-    /// After receiving the `ExternalAccountAuthorization` returned by this function, you must present an `SFSafariViewController` to the user using the `authorizationURL` in the returned object to complete the provider authorization flow.
+    /// After receiving the `ExternalAccountAuthorization` returned by this function, your app must present an `SFSafariViewController` to the user using the `authorizationURL` in the returned object to complete the provider authorization flow.
     ///
     /// Upon completion of the connection flow in the Safari view, the participant is sent to the `finalRedirectURL` to indicate that the browser can be dismissed. Your app should intercept this URL via the AppDelegate's `application(_:open:options:)` or `application(_:continue:restorationHandler:)` or the SwiftUI `onOpenURL` modifier, and programmatically dismiss the SFSafariViewController when the URL is opened. Your app can use a specific path in this URL in order to differentiate it from other URLs your app may support.
     ///
@@ -31,7 +31,7 @@ public extension ParticipantSession {
     /// - [Universal Link](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html), e.g. `https://my.app/linkprovidercompletion`. The Universal Link domain and path must be fully configured in your app's entitlements file, the apple-app-site-association file hosted at the `my.app` domain, etc.
     /// - [Custom scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app), e.g. `myapp://linkprovidercompletion`. Your app's Info.plist file must register the scheme `myapp` in the URL Types list.
     ///
-    /// Contact [CareEvolution support](https://developer.mydatahelps.org/help.html) to have your `finalRedirectURL` added to the list of allowed URLs in MyDataHelps. If the URL is not in the allow list, this API will produce an error result.
+    /// Contact [CareEvolution support](https://developer.mydatahelps.org/help.html) to have your `finalRedirectURL` added to the list of allowed URLs in MyDataHelps. If the URL is not in the allowed list, the provider authorization flow will fail to load correctly.
     /// - Parameters:
     ///   - provider: The external account provider to connect.
     ///   - finalRedirectURL: A URL that is configured to open your app via a custom scheme or Universal Link.

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
@@ -9,11 +9,18 @@ import Foundation
 
 public extension ParticipantSession {
     /// Query the list of external account providers supported by MyDataHelps.
+    ///
+    /// To fetch the first page of results, call this with a new ``ExternalAccountProvidersQuery`` object. If there are additional pages available, the next page can be fetched by using `ExternalAccountProvidersQuery.page(after:)` to construct a query for the following page.
     /// - Parameters:
     ///   - query: Specifies how to filter the providers.
-    ///   - completion: Called when the request is complete, with an array of `ExternalAccountProvider` on success or an error on failure.
-    func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<[ExternalAccountProvider], MyDataHelpsError>) -> Void) {
-        load(resource: ExternalAccountProvidersQueryResource(query: query), completion: completion)
+    ///   - completion: Called when the request is complete, with a ``ExternalAccountProvidersResultPage`` instance on success or an error on failure. Results are ordered by name.
+    func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<ExternalAccountProvidersResultPage, MyDataHelpsError>) -> Void) {
+        load(resource: ExternalAccountProvidersQueryResource(query: query)) {
+            (result: Result<ExternalAccountProvidersResultPage.APIResponse, MyDataHelpsError>) in
+            completion(result.map {
+                ExternalAccountProvidersResultPage(result: $0, query: query)
+            })
+        }
     }
         
     /// Initiates a new connected external account. Grants access to a secure OAuth connection to the specified external account provider, where the participant can provide their provider credentials and authorize MyDataHelps to retrieve data from the account.
@@ -42,20 +49,69 @@ public extension ParticipantSession {
     }
 }
 
-/// Specifies filtering criteria for external account provider queries. All filter criteria are optional; specifying no criteria will produce a list of all available external account providers.
+/// Specifies filtering and page-navigation criteria for external account provider queries.
+///
+/// All filter criteria are optional. Set non-nil/non-default values only for the properties you want to use for filtering.
 public struct ExternalAccountProvidersQuery {
+    /// The default and maximum number of results per page.
+    public static let defaultLimit = 100
+    /// The page index that indicates the first page of results.
+    public static let firstPageNumber = 0
+    
     /// Limit search results to account providers whose keyword, postal code, city, or state begins with the search string. Case-insensitive.
     public let search: String?
     /// Limit search results to account providers with the specified category.
     public let category: ExternalAccountProviderCategory?
+    /// Maximum number of results per page. Default and maximum value is 100.
+    public let limit: Int
+    /// Identifies a specific page of data to fetch. The default is `firstPageNumber`, fetching the first page of results. For convenience, to fetch the page following a given ``ExternalAccountProvidersResultPage``, use `page(after:)` to construct a copy of this query with `pageNumber` incremented.
+    public let pageNumber: Int
     
-    /// Initializes a new query for external account providers with various filters.
+    /// Initializes a new query for a page of external account providers with various filters.
     /// - Parameters:
     ///   - search: Limit search results to account providers whose keyword, postal code, city, or state begins with the search string. Case-insensitive.
     ///   - category: Limit search results to account providers with the specified category.
-    public init(search: String? = nil, category: ExternalAccountProviderCategory? = nil) {
+    ///   - limit: Limit search results to account providers with the specified category.
+    ///   - pageNumber: Identifies a specific page of data to fetch. The default is `firstPageNumber`, fetching the first page of results. For convenience, to fetch the page following a given ``ExternalAccountProvidersResultPage``, use `page(after:)` to construct a copy of this query with `pageNumber` incremented.
+    public init(search: String? = nil, category: ExternalAccountProviderCategory? = nil, limit: Int = defaultLimit, pageNumber: Int = firstPageNumber) {
         self.search = search
         self.category = category
+        self.limit = max(1, min(limit, Self.defaultLimit))
+        self.pageNumber = max(Self.firstPageNumber, pageNumber)
+    }
+    
+    /// Creates a copy of this query for a page of results following the given page, with the same filters as the original query.
+    /// - Parameter page: the previous page of results, which should have been produced with this query.
+    /// - Returns: A copy of this query, with `pageNumber` set to fetch results following the given `page`, if there are additional results to fetch. If there are no additional results available, returns `nil`. The query returned, if any, has the same filters as the original.
+    public func page(after page: ExternalAccountProvidersResultPage) -> ExternalAccountProvidersQuery? {
+        guard page.externalAccountProviders.count >= limit else {
+            return nil
+        }
+        return ExternalAccountProvidersQuery(search: self.search, category: self.category, limit: self.limit, pageNumber: page.pageNumber + 1)
+    }
+}
+
+/// A page of external account providers.
+///
+/// Call `page(after:)` on the original `ExternalAccountProvidersQuery` that produced these results to construct a query that will fetch the next page.
+public struct ExternalAccountProvidersResultPage {
+    internal struct APIResponse: Decodable {
+        let externalAccountProviders: [ExternalAccountProvider]
+        let totalExternalAccountProviders: Int
+    }
+    
+    /// A list of providers filtered by the query criteria.
+    public let externalAccountProviders: [ExternalAccountProvider]
+    /// The total number of providers across all pages of results matching the query criteria.
+    public let totalCount: Int
+    /// The page index for this specific page of results.
+    public let pageNumber: Int
+    
+    /// `APIResponse`—the data returned from the API endpoint—does not include a `pageNumber`. Combine the APIResponse with the query that produced the response so the caller has access to the `pageNumber` to safely perform paging.
+    internal init(result: APIResponse, query: ExternalAccountProvidersQuery) {
+        self.externalAccountProviders = result.externalAccountProviders
+        self.totalCount = result.totalExternalAccountProviders
+        self.pageNumber = query.pageNumber
     }
 }
 

--- a/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
+++ b/MyDataHelpsKit/ProviderConnections/ExternalAccountProviders.swift
@@ -84,10 +84,11 @@ public struct ExternalAccountProvidersQuery {
     /// - Parameter page: the previous page of results, which should have been produced with this query.
     /// - Returns: A copy of this query, with `pageNumber` set to fetch results following the given `page`, if there are additional results to fetch. If there are no additional results available, returns `nil`. The query returned, if any, has the same filters as the original.
     public func page(after page: ExternalAccountProvidersResultPage) -> ExternalAccountProvidersQuery? {
-        guard page.externalAccountProviders.count >= limit else {
+        let nextPageNumber = page.pageNumber + 1
+        guard limit > 0, (nextPageNumber * limit) < page.totalCount else {
             return nil
         }
-        return ExternalAccountProvidersQuery(search: self.search, category: self.category, limit: self.limit, pageNumber: page.pageNumber + 1)
+        return ExternalAccountProvidersQuery(search: self.search, category: self.category, limit: self.limit, pageNumber: nextPageNumber)
     }
 }
 

--- a/MyDataHelpsKit/Session/ParticipantAccessToken.swift
+++ b/MyDataHelpsKit/Session/ParticipantAccessToken.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Represents an access token for a single participant.
 ///
-/// See [documentation on Participant Tokens](https://developer.mydatahelps.org/sdk/participant_tokens.html) for more information about obtaining an access token.
+/// See [documentation on Participant Tokens](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for more information about obtaining an access token.
 ///
 /// **Warning:** Never expose a service token in a client application or to the SDK. Use participant tokens instead.
 public struct ParticipantAccessToken {

--- a/MyDataHelpsKitTests/ExternalAccountsTests.swift
+++ b/MyDataHelpsKitTests/ExternalAccountsTests.swift
@@ -15,12 +15,50 @@ private let accountsJSON = """
     """.data(using: .utf8)!
 
 private let providersJSON = """
-    [
-        { "id": 1, "name": "MyDataHelps Demo Provider", "category": "Provider", "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png" }
-    ]
+    {
+        "externalAccountProviders": [
+            { "id": 1, "name": "MyDataHelps Demo Provider", "category": "Provider", "logoUrl": "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png" }
+        ],
+        "totalExternalAccountProviders": 35
+    }
     """.data(using: .utf8)!
 
 class ExternalAccountsTests: XCTestCase {
+    func testExternalAccountProvidersQuery() {
+        var query = ExternalAccountProvidersQuery()
+        XCTAssertEqual(query.pageNumber, ExternalAccountProvidersQuery.firstPageNumber, "Defaults to query for first page")
+        XCTAssertEqual(query.limit, ExternalAccountProvidersQuery.defaultLimit, "Uses default limit")
+        
+        query = ExternalAccountProvidersQuery(search: "search text", category: .provider, limit: 25, pageNumber: 2)
+        XCTAssertEqual(query.search, "search text", "Search is correct")
+        XCTAssertEqual(query.category, .provider, "Category is correct")
+        XCTAssertEqual(query.limit, 25, "Valid limit is correct")
+        XCTAssertEqual(query.pageNumber, 2, "Valid page number is correct")
+        
+        XCTAssertEqual(ExternalAccountProvidersQuery(limit: -10).limit, 1, "Lower bound for limit")
+        XCTAssertEqual(ExternalAccountProvidersQuery(limit: 1000).limit, ExternalAccountProvidersQuery.defaultLimit, "Upper bound for limit")
+        
+        XCTAssertEqual(ExternalAccountProvidersQuery(pageNumber: -1).pageNumber, ExternalAccountProvidersQuery.firstPageNumber, "Lower bound for page number")
+        
+        query = ExternalAccountProvidersQuery(search: "search text", category: .deviceManufacturer, limit: 2, pageNumber: 0)
+        let provider1 = ExternalAccountProvider(id: .init(1), name: "Provider", category: .deviceManufacturer, logoURL: nil)
+        let fullResultPage0 = ExternalAccountProvidersResultPage(result: .init(externalAccountProviders: [provider1, provider1], totalExternalAccountProviders: 5), query: query)
+        let fullResultPage1 = ExternalAccountProvidersResultPage(result: .init(externalAccountProviders: [provider1, provider1], totalExternalAccountProviders: 5), query: ExternalAccountProvidersQuery(search: "search text", category: .deviceManufacturer, limit: 2, pageNumber: 1))
+        let partialResultPage = ExternalAccountProvidersResultPage(result: .init(externalAccountProviders: [provider1], totalExternalAccountProviders: 5), query: query)
+        let emptyResultPage = ExternalAccountProvidersResultPage(result: .init(externalAccountProviders: [], totalExternalAccountProviders: 5), query: query)
+        
+        let pageAfter = query.page(after: fullResultPage0)
+        XCTAssertEqual(pageAfter?.search, "search text", "Copies search to next page query")
+        XCTAssertEqual(pageAfter?.category, .deviceManufacturer, "Copies category to next page query")
+        XCTAssertEqual(pageAfter?.limit, 2, "Copies limit to next page query")
+        XCTAssertEqual(pageAfter?.pageNumber, 1, "Increments page number")
+        XCTAssertEqual(pageAfter?.page(after: fullResultPage1)?.pageNumber, 2, "Increments page number again")
+        XCTAssertEqual(query.page(after: fullResultPage1)?.pageNumber, 2, "Increments page number based on result's page number, not the original query")
+        
+        XCTAssertNil(pageAfter?.page(after: partialResultPage), "Partial result indicates end of pages")
+        XCTAssertNil(pageAfter?.page(after: emptyResultPage), "Empty result indicates end of pages")
+    }
+    
     func testExternalAccountJSONDecodes() throws {
         let list = try JSONDecoder.myDataHelpsDecoder.decode([ExternalAccount].self, from: accountsJSON)
         XCTAssertEqual(list.count, 1)
@@ -33,11 +71,13 @@ class ExternalAccountsTests: XCTestCase {
         }
     }
     
-    func testProviderAccountsJSONDecodes() throws {
-        let list = try JSONDecoder.myDataHelpsDecoder.decode([ExternalAccountProvider].self, from: providersJSON)
-        XCTAssertEqual(list.count, 1)
-        if let first = list.first {
+    func testExternalAccountProvidersResultPageJSONDecodes() throws {
+        let page = try JSONDecoder.myDataHelpsDecoder.decode(ExternalAccountProvidersResultPage.APIResponse.self, from: providersJSON)
+        XCTAssertEqual(page.externalAccountProviders.count, 1)
+        XCTAssertEqual(page.totalExternalAccountProviders, 35)
+        if let first = page.externalAccountProviders.first {
             XCTAssertEqual(first.id.value, 1)
+            XCTAssertEqual(first.name, "MyDataHelps Demo Provider")
             XCTAssertEqual(first.category, .provider)
             XCTAssertEqual(first.logoURL?.absoluteString, "https://developer.mydatahelps.org/assets/images/mydatahelps-logo.png")
         }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [GitHub releases](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releas
 
 1. Add MyDataHelpsKit to your Xcode workspace. See the [installation](#installation) section below for details
 2. Create a `MyDataHelpsClient` object for communication with MyDataHelps. This object can be retained for the lifetime of your app
-3. Obtain a [participant access token](https://developer.mydatahelps.org/sdk/participant_tokens.html) for the authorized MyDataHelps participant. Note that your app is responsible for renewing the access token when it expires
+3. Obtain a [participant access token](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for the authorized MyDataHelps participant. Note that your app is responsible for renewing the access token when it expires
 4. Create a `ParticipantSession` using the access token. This is the primary interface for interacting with MyDataHelps. It can be retained for as long as the participant's acess token is valid; create a new `ParticipantSession` when you renew the access token or when a different participant logs in
 5. Use `ParticipantSession` functions to perform MyDataHelps operations and requests for the participant
 

--- a/example/MyDataHelpsKit-Example/PagedView/PagedView.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/PagedView.swift
@@ -26,6 +26,7 @@ struct PagedView<SourceType, ViewType>: View where SourceType: PagedModelSource,
                 Section {
                     ForEach(model.items) { item in
                         model.viewProvider(item)
+                            .onTapGesture { model.selectedItem = item }
                             .onAppear(perform: {
                                 if model.isLastItem(item) {
                                     model.loadNextPage()

--- a/example/MyDataHelpsKit-Example/PagedView/PagedViewModel.swift
+++ b/example/MyDataHelpsKit-Example/PagedView/PagedViewModel.swift
@@ -36,7 +36,8 @@ class PagedViewModel<SourceType: PagedModelSource, ItemViewType: View>: Observab
     
     @Published var state: State
     @Published var items: [ItemType]
-
+    @Published var selectedItem: ItemType?
+    
     init(source: SourceType, viewProvider: @escaping (ItemType) -> ItemViewType) {
         self.source = source
         self.viewProvider = viewProvider

--- a/example/MyDataHelpsKit-Example/ProviderConnections/ExternalAccountsListView.swift
+++ b/example/MyDataHelpsKit-Example/ProviderConnections/ExternalAccountsListView.swift
@@ -78,8 +78,9 @@ struct ExternalAccountsListView: View {
         .actionSheet(item: $selected) { account in
             ActionSheet(title: Text(account.provider.name), message: nil, buttons: actionButtons(account: account))
         }
+        /// EXERCISE: Try non-nil `search` and `category` values to customize filtering providers.
         .navigationBarItems(trailing: NavigationLink(destination:
-            ProvidersListView(model: ProvidersListViewModel(session: model.session))
+            ExternalAccountProviderView.pageView(session: model.session, search: nil, category: nil)
                 .navigationTitle("External Account Providers"), label: {
             Image(systemName: "plus")
         }))

--- a/example/MyDataHelpsKit-Example/ProviderConnections/ProviderConnectionAuthViewRepresentable.swift
+++ b/example/MyDataHelpsKit-Example/ProviderConnections/ProviderConnectionAuthViewRepresentable.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import MyDataHelpsKit
 import SafariServices
 
+/// This is a SwiftUI wrapper for SFSafariViewController, used for presenting a provider connection authorization flow to the user. This view is constructed using the `authorizationURL` property of an ``ExternalAccountAuthorization`` object produced by ParticipantSession's `connectExternalAccount` function.
+///
+/// See `ParticipantSession.connectExternalAccount` documentation for details.
 struct ProviderConnectionAuthViewRepresentable: UIViewControllerRepresentable {
     typealias UIViewControllerType = SFSafariViewController
     

--- a/example/MyDataHelpsKit-Example/ProviderConnections/ProvidersListView.swift
+++ b/example/MyDataHelpsKit-Example/ProviderConnections/ProvidersListView.swift
@@ -8,91 +8,16 @@
 import SwiftUI
 import MyDataHelpsKit
 
-extension ExternalAccountAuthorization: Identifiable {
-    public var id: ExternalAccountProvider.ID { provider.id }
-}
-
-class ProvidersListViewModel: ObservableObject {
-    private let session: ParticipantSessionType
-    let query: ExternalAccountProvidersQuery
-    @Published var providers: Result<[ExternalAccountProvider], MyDataHelpsError>?
-    
-    @AppStorage("settings_redirectURL") private var finalRedirectURLPreference: String = "linkprovideraccounts://sandbox"
-    
-    init(session: ParticipantSessionType) {
-        self.session = session
-        /// EXERCISE: Set non-nil `search` and `category` values to customize filtering providers.
-        self.query = ExternalAccountProvidersQuery(search: nil, category: nil)
-        self.providers = nil
-        session.queryExternalAccountProviders(query) {
-            self.providers = $0
-        }
-    }
-    
-    func connect(_ provider: ExternalAccountProvider, completion: @escaping (Result<ExternalAccountAuthorization, MyDataHelpsError>) -> Void) {
-        guard let finalRedirectURL = URL(string: finalRedirectURLPreference) else {
-            return
-        }
-        session.connectExternalAccount(provider: provider, finalRedirectURL: finalRedirectURL, completion: completion)
-    }
-}
-
-struct ProvidersListView: View {
-    @StateObject var model: ProvidersListViewModel
-    @State private var newConnection: ExternalAccountAuthorization?
-    @State private var errorModel: ErrorView.Model?
-    
-    var body: some View {
-        Group {
-            switch model.providers {
-            case .none:
-                ProgressView()
-            case let .some(.failure(error)):
-                List {
-                    ErrorView(model: .init(title: "Failed to load providers", error: error))
-                }
-            case let .some(.success(providers)) where providers.isEmpty:
-                List {
-                    Text("No providers found")
-                }
-            case let .some(.success(providers)):
-                List(providers) { provider in
-                    ExternalAccountProviderView(provider: provider)
-                        .onTapGesture { connect(provider) }
-                }
-            }
-        }
-        .sheet(item: $newConnection) { connection in
-            ProviderConnectionAuthViewRepresentable(url: connection.authorizationURL, presentation: $newConnection)
-        }
-        .alert(item: $errorModel, content: {
-            Alert(title: Text($0.errorDescription))
-        })
-        // In a UIKit app, implement this in AppDelegate as part of `application(_:open:options:)` (for custom scheme URLs) or `application(_:continue:restorationHandler:)` (for Universal Links).
-        .onOpenURL { url in
-            if url.scheme == newConnection?.finalRedirectURL.scheme,
-               url.path == newConnection?.finalRedirectURL.path {
-                newConnection = nil
-            }
-        }
-    }
-    
-    private func connect(_ provider: ExternalAccountProvider) {
-        guard newConnection == nil else { return }
-        errorModel = nil
-        model.connect(provider) {
-            switch $0 {
-            case let .success(connection):
-                newConnection = connection
-            case let .failure(error):
-                errorModel = .init(title: "Error", error: error)
-            }
-        }
-    }
-}
-
 struct ExternalAccountProviderView: View {
     let provider: ExternalAccountProvider
+    
+    static func pageView(session: ParticipantSessionType, search: String?, category: ExternalAccountProviderCategory?) -> some View {
+        let query = ExternalAccountProvidersQuery(search: search, category: category, limit: 25)
+        let source = ExternalAccountProvidersSource(session: session, query: query)
+        return ExternalAccountProviderPagedView(session: session, model: .init(source: source) { item in
+            ExternalAccountProviderView(provider: item)
+        })
+    }
     
     var body: some View {
         HStack(alignment: .center) {
@@ -116,16 +41,114 @@ struct ExternalAccountProviderView: View {
     }
 }
 
-struct ProvidersListView_Previews: PreviewProvider {
-    private static var model: ProvidersListViewModel {
-        ProvidersListViewModel(session: ParticipantSessionPreview())
+struct ExternalAccountProviderPagedView: View {
+    @AppStorage("settings_redirectURL") private var finalRedirectURLPreference: String = "linkprovideraccounts://sandbox"
+    let session: ParticipantSessionType
+    @StateObject var model: PagedViewModel<ExternalAccountProvidersSource, ExternalAccountProviderView>
+    @State private var newConnection: ExternalAccountAuthorization?
+    @State private var errorModel: ErrorView.Model?
+    
+    var body: some View {
+        PagedView(model: model)
+            .sheet(item: $newConnection) { connection in
+                ProviderConnectionAuthViewRepresentable(url: connection.authorizationURL, presentation: $newConnection)
+            }
+            .alert(item: $errorModel, content: {
+                Alert(title: Text($0.errorDescription))
+            })
+            // In a UIKit app, implement this in AppDelegate as part of `application(_:open:options:)` (for custom scheme URLs) or `application(_:continue:restorationHandler:)` (for Universal Links).
+            .onChange(of: model.selectedItem, perform: beginConnection)
+            .onOpenURL { url in
+                if url.scheme == newConnection?.finalRedirectURL.scheme,
+                   url.path == newConnection?.finalRedirectURL.path {
+                    newConnection = nil
+                    model.selectedItem = nil
+                }
+            }
     }
     
+    private func beginConnection(_ provider: ExternalAccountProvider?) {
+        guard let provider = provider, newConnection == nil else { return }
+        errorModel = nil
+        guard let finalRedirectURL = URL(string: finalRedirectURLPreference) else {
+            return
+        }
+        
+        session.connectExternalAccount(provider: provider, finalRedirectURL: finalRedirectURL) {
+            switch $0 {
+            case let .success(connection):
+                newConnection = connection
+            case let .failure(error):
+                errorModel = .init(title: "Error", error: error)
+                newConnection = nil
+                model.selectedItem = nil
+            }
+        }
+    }
+}
+
+struct ExternalAccountProvidersResultPageViewModel: PageModelType {
+    let page: ExternalAccountProvidersResultPage
+    let query: ExternalAccountProvidersQuery
+    
+    /// For compatibility with PagedView; just indicates whether there is another page to load. The query itself uses numeric `pageNumber` instead of `nextPageID`.
+    var nextPageID: ScopedIdentifier<ExternalAccountProvidersResultPageViewModel, String>? {
+        if query.page(after: page) == nil {
+            return nil
+        } else {
+            return .init("next")
+        }
+    }
+    
+    func pageItems(session: ParticipantSessionType) -> [ExternalAccountProvider] {
+        page.externalAccountProviders
+    }
+}
+
+class ExternalAccountProvidersSource: PagedModelSource {
+    let session: ParticipantSessionType
+    private let query: ExternalAccountProvidersQuery
+    
+    init(session: ParticipantSessionType, query: ExternalAccountProvidersQuery) {
+        self.session = session
+        self.query = query
+    }
+    
+    func loadPage(after result: ExternalAccountProvidersResultPageViewModel?, completion: @escaping (Result<ExternalAccountProvidersResultPageViewModel, MyDataHelpsError>) -> Void) {
+        if let query = query(after: result) {
+            session.queryExternalAccountProviders(query) { result in
+                completion(result.map { .init(page: $0, query: query) })
+            }
+        }
+    }
+    
+    private func query(after result: ExternalAccountProvidersResultPageViewModel?) -> ExternalAccountProvidersQuery? {
+        if let result = result {
+            return query.page(after: result.page)
+        } else {
+            return query
+        }
+    }
+}
+
+// Equatable conformance required for `.onChange(of: model.selectedItem)` below.
+extension ExternalAccountProvider: Equatable {
+    public static func == (lhs: ExternalAccountProvider, rhs: ExternalAccountProvider) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+// Identifiable conformance required for `.sheet(item: $newConnection)` below.
+extension ExternalAccountAuthorization: Identifiable {
+    public var id: ExternalAccountProvider.ID { provider.id }
+}
+
+struct ProvidersListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            ProvidersListView(model: Self.model)
+            ExternalAccountProviderView.pageView(session: ParticipantSessionPreview(), search: nil, category: nil)
                 .navigationTitle("External Providers")
-                .environmentObject(RemoteImageCache())
         }
+        .environmentObject(RemoteImageCache())
     }
 }

--- a/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
+++ b/example/MyDataHelpsKit-Example/Session/ParticipantSessionType.swift
@@ -17,7 +17,7 @@ protocol ParticipantSessionType {
     func deleteSurveyResult(_ surveyResultID: SurveyResult.ID, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void)
     func queryNotifications(_ query: NotificationHistoryQuery, completion: @escaping (Result<NotificationHistoryPage, MyDataHelpsError>) -> Void)
     func persistDeviceData(_ dataPoints: [DeviceDataPointPersistModel], completion: @escaping (Result<Void, MyDataHelpsError>) -> Void)
-    func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<[ExternalAccountProvider], MyDataHelpsError>) -> Void)
+    func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<ExternalAccountProvidersResultPage, MyDataHelpsError>) -> Void)
     func connectExternalAccount(provider: ExternalAccountProvider, finalRedirectURL: URL, completion: @escaping (Result<ExternalAccountAuthorization, MyDataHelpsError>) -> Void)
     func listExternalAccounts(completion: @escaping (Result<[ExternalAccount], MyDataHelpsError>) -> Void)
     func refreshExternalAccount(_ account: ExternalAccount, completion: @escaping (Result<Void, MyDataHelpsError>) -> Void)
@@ -66,8 +66,7 @@ class ParticipantSessionPreview: ParticipantSessionType {
         completion(.success(()))
     }
     
-    func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<[ExternalAccountProvider], MyDataHelpsError>) -> Void) {
-        delayedSuccess(data: PreviewData.providersJSON, completion: completion)
+    func queryExternalAccountProviders(_ query: ExternalAccountProvidersQuery, completion: @escaping (Result<ExternalAccountProvidersResultPage, MyDataHelpsError>) -> Void) {
     }
     
     func connectExternalAccount(provider: ExternalAccountProvider, finalRedirectURL: URL, completion: @escaping (Result<ExternalAccountAuthorization, MyDataHelpsError>) -> Void) {
@@ -114,9 +113,10 @@ enum PreviewData {
     """
     
     static let providersJSON = """
-    [
-        \(provider1JSONText)
-    ]
+    {
+        "externalAccountProviders": [ \(provider1JSONText) ],
+        "totalExternalAccountProviders": 35
+    }
     """.data(using: .utf8)!
     
     static let accountsJSON = """

--- a/example/MyDataHelpsKit-Example/Session/SessionModel.swift
+++ b/example/MyDataHelpsKit-Example/Session/SessionModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import MyDataHelpsKit
 
-/// Produces a `ParticipantSession` object with a `ParticipantAccessToken` manually entered into the UI. See [documentation on Participant Tokens](https://developer.mydatahelps.org/sdk/participant_tokens.html) for information about obtaining an access token.
+/// Produces a `ParticipantSession` object with a `ParticipantAccessToken` manually entered into the UI. See [documentation on Participant Tokens](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for information about obtaining an access token.
 @MainActor class SessionModel: ObservableObject {
     let client: MyDataHelpsClient
     @Published var token: String = ""

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 A SwiftUI app demonstrating usage of MyDataHelpsKit. For more information about the MyDataHelpsKit SDK, see the main [readme file](https://github.com/CareEvolution/MyDataHelpsKit-iOS).
 
-To get started, open `MyDataHelpsKit-Example.xcworkspace` in Xcode and run the app. Once the app launches, you will need to enter a valid participant token to authenticate and use the app's functionality. See [documentation on Participant Tokens](https://developer.mydatahelps.org/sdk/participant_tokens.html) for more information about obtaining an access token.
+To get started, open `MyDataHelpsKit-Example.xcworkspace` in Xcode and run the app. Once the app launches, you will need to enter a valid participant token to authenticate and use the app's functionality. See [documentation on Participant Tokens](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for more information about obtaining an access token.
 
 Once you enter a participant token, the example app initializes a `ParticipantSession` and displays the RootMenuView, from which you can navigate to various other views to demonstrate each of the MyDataHelpsKit APIs.
 

--- a/example/README.md
+++ b/example/README.md
@@ -18,27 +18,27 @@ The headings below describe the functionality you can find in each subview acces
 
 ### Participant Info
 
-- After entering a valid participant token and proceeding to the main menu, the app immediately loads and displays the ParticipantInfo object via `ParticipantSession.getParticipantInfo`
-- Modify `ParticipantInfoView` to experiment with displaying various ParticipantInfo properties or demographic fields
+- After entering a valid participant token and proceeding to the main menu, the app immediately loads and displays the ParticipantInfo object via `ParticipantSession.getParticipantInfo`.
+- Modify `ParticipantInfoView` to experiment with displaying various ParticipantInfo properties or demographic fields.
 
 ### Query Survey Tasks
 
-- Demonstrates usage of `ParticipantSession.querySurveyTasks`. Modify the `SurveyTaskView.pageView` function to experiment with different query parameters
-- Demonstrates `ParticipantSession.querySurveyAnswers`, by tapping on completed surveys
+- Demonstrates usage of `ParticipantSession.querySurveyTasks`. Modify the `SurveyTaskView.pageView` function to experiment with different query parameters.
+- Demonstrates `ParticipantSession.querySurveyAnswers`, by tapping on completed surveys.
 
 ### Query Survey Answers
 
-- Demonstrates general usage of `ParticipantSession.querySurveyAnswers`. Modify the `SurveyAnswerView.pageView` function to experiment with different query parameters
-- Demonstrates deleting specific survey results, if deletion is enabled for the survey in MyDataHelps
+- Demonstrates general usage of `ParticipantSession.querySurveyAnswers`. Modify the `SurveyAnswerView.pageView` function to experiment with different query parameters.
+- Demonstrates deleting specific survey results, if deletion is enabled for the survey in MyDataHelps.
 
 ### Device Data
 
-- **Device Data: Apple Health** and **Device Data: Project** demonstrates using `ParticipantSession.queryDeviceData` to query and list device data under the Apple Health or Project namespaces. Modify `RootMenuView` and the `DeviceDataPointView.pageView` function to experiment with different query parameters
-- **Persist New Device Data** demonstrates creating and saving new device data in the Project namespace
+- **Device Data: Apple Health** and **Device Data: Project** demonstrates using `ParticipantSession.queryDeviceData` to query and list device data under the Apple Health or Project namespaces. Modify `RootMenuView` and the `DeviceDataPointView.pageView` function to experiment with different query parameters.
+- **Persist New Device Data** demonstrates creating and saving new device data in the Project namespace.
 
 ### Query Notifications
 
-- Demonstrates usage of `ParticipantSession.queryNotifications`. Modify the `NotificationHistoryView.pageView` function to experiment with different query parameters. `NotificationHistoryView.Model` demonstrates various ways to access the different types of notification content available
+- Demonstrates usage of `ParticipantSession.queryNotifications`. Modify the `NotificationHistoryView.pageView` function to experiment with different query parameters. `NotificationHistoryView.Model` demonstrates various ways to access the different types of notification content available.
 
 ### MyDataHelps Embeddable Surveys
 
@@ -46,6 +46,6 @@ To see examples of using `EmbeddableSurveyViewController` to present MyDataHelps
 
 ### External Accounts
 
-- The top level External Accounts screen demonstrates usage of `ParticipantSession.listExternalAccounts` to view, update, and delete connected external account providers
-- Tap the `+` button on that screen to view available external account providers via `ParticipantSession.queryExternalAccountProviders`. Modify `ProvidersListViewModel` to experiment with different query parameters
-- Selecting an external account provider demonstrates the provider connection authorization flow, using `ParticipantSession.connectExternalAccount` to initiate the connection, and `SFSafariViewController` to present the UI. Note that MyDataHelpsKit only supplies a URL to present, your app (as demonstrated by the example app) is responsible for presenting a Safari view with that URL to the participant, and dismissing the Safari view by intercepting a special link. See `ParticipantSession.connectExternalAccount` documentation for details
+- The top level External Accounts screen demonstrates usage of `ParticipantSession.listExternalAccounts` to view, update, and delete connected external account providers.
+- Tap the `+` button on that screen to view available external account providers via `ParticipantSession.queryExternalAccountProviders`. Modify the call to `ExternalAccountProviderView.pageView` in ExternalAccountsListView.swift to experiment with different query parameters.
+- Selecting an external account provider demonstrates the provider connection authorization flow, using `ParticipantSession.connectExternalAccount` to initiate the connection, and `SFSafariViewController` to present the UI. Note that MyDataHelpsKit only supplies a URL to present, your app (as demonstrated by the example app) is responsible for presenting a Safari view with that URL to the participant, and dismissing the Safari view by intercepting a special link. See `ParticipantSession.connectExternalAccount` documentation for details.


### PR DESCRIPTION
## Overview

See #27.

Note that the paging mechanism for this API endpoint uses numeric page indexes instead of opaque `nextPageID` identifiers, so the model structs and example app view code are a little different than the other paged queries.

Also updates documentation URLs for Participant Access Tokens for #50.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

- [X] All public symbols are documented using Swift Markup comments.
- [ ] If this feature requires a developer doc update, tag `@CareEvolution/api-docs`. _Will make a single issue for all v2.0.0 updates once the 2.0 release is ready_
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
