### PR TITLE
Token doc URL updates, style fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ Describe briefly what security risks you considered, why they don't apply, or ho
 ## Checklist
 
 - [ ] All public symbols are documented using Swift Markup comments.
-- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.
+- [ ] If this feature requires a developer doc update, tag `@CareEvolution/api-docs`.
 - [ ] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
 - [ ] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.
 

--- a/MyDataHelpsKit/Model/Project.swift
+++ b/MyDataHelpsKit/Model/Project.swift
@@ -79,6 +79,7 @@ public struct Organization: Decodable {
     public let color: String
 }
 
+/// Settings related to data collection for a participant and their project.
 public struct ProjectDataCollectionSettings: Decodable {
     /// Indicates whether Fitbit data collection is enabled for this project.
     public let fitbitEnabled: Bool

--- a/MyDataHelpsKit/Session/ParticipantAccessToken.swift
+++ b/MyDataHelpsKit/Session/ParticipantAccessToken.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Represents an access token for a single participant.
 ///
-/// See [documentation on Participant Tokens](https://developer.mydatahelps.org/sdk/participant_tokens.html) for more information about obtaining an access token.
+/// See [documentation on Participant Tokens](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for more information about obtaining an access token.
 ///
 /// **Warning:** Never expose a service token in a client application or to the SDK. Use participant tokens instead.
 public struct ParticipantAccessToken {

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ See [GitHub releases](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releas
 
 ## Getting started
 
-1. Add MyDataHelpsKit to your Xcode workspace. See the [installation](#installation) section below for details
-2. Create a `MyDataHelpsClient` object for communication with MyDataHelps. This object can be retained for the lifetime of your app
-3. Obtain a [participant access token](https://developer.mydatahelps.org/sdk/participant_tokens.html) for the authorized MyDataHelps participant. Note that your app is responsible for renewing the access token when it expires
-4. Create a `ParticipantSession` using the access token. This is the primary interface for interacting with MyDataHelps. It can be retained for as long as the participant's acess token is valid; create a new `ParticipantSession` when you renew the access token or when a different participant logs in
-5. Use `ParticipantSession` functions to perform MyDataHelps operations and requests for the participant
+1. Add MyDataHelpsKit to your Xcode workspace. See the [installation](#installation) section below for details.
+2. Create a `MyDataHelpsClient` object for communication with MyDataHelps. This object can be retained for the lifetime of your app.
+3. Obtain a [participant access token](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for the authorized MyDataHelps participant. Note that your app is responsible for renewing the access token when it expires.
+4. Create a `ParticipantSession` using the access token. This is the primary interface for interacting with MyDataHelps. It can be retained for as long as the participant's access token is valid; create a new `ParticipantSession` when you renew the access token or when a different participant logs in.
+5. Use `ParticipantSession` functions to perform MyDataHelps operations and requests for the participant.
 
 See [online documentation](https://developer.mydatahelps.org/ios/) or integrated Xcode symbol documentation for details about specific operations and model types.
 
@@ -61,9 +61,9 @@ Or in your Xcode project, go to File > Swift Packages > Add Package Dependency a
 
 Use the [standard Carthage workflow](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for static frameworks:
 
-1. Add `github "CareEvolution/MyDataHelpsKit-iOS"` to your Cartfile
+1. Add `github "CareEvolution/MyDataHelpsKit-iOS"` to your Cartfile.
 2. Run `carthage update --use-xcframeworks`
-3. Open your app target's General settings tab in Xcode. In Finder, go to the `Carthage/Build` folder, and drag and drop `MyDataHelpsKit.xcframework` from the `Carthage/Build` folder into the "Frameworks, Libraries, and Embedded Content" section in Xcode
+3. Open your app target's General settings tab in Xcode. In Finder, go to the `Carthage/Build` folder, and drag and drop `MyDataHelpsKit.xcframework` from the `Carthage/Build` folder into the "Frameworks, Libraries, and Embedded Content" section in Xcode.
 
 To update MyDataHelpsKit to a newer version, run `carthage update --use-xcframeworks`, optionally appending MyDataHelpsKit-iOS to the command to only update this SDK and not other Carthage dependencies.
 
@@ -71,16 +71,16 @@ To update MyDataHelpsKit to a newer version, run `carthage update --use-xcframew
 
 Use the [standard Cocoapods workflow](https://guides.cocoapods.org/using/using-cocoapods.html):
 
-1. Create a Podfile for your project using `pod init` if needed
-2. Add `pod 'MyDataHelpsKit'` to your Podfile
+1. Create a Podfile for your project using `pod init` if needed.
+2. Add `pod 'MyDataHelpsKit'` to your Podfile.
 3. Run `pod install`
 
 To update MyDataHelpsKit to a newer version, run `pod update`, optionally appending MyDataHelpsKit to the command to only update this SDK and not other Cocoapods dependencies.
 
 ### Manual integration
 
-1. Download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases) from GitHub
-2. From Finder, drag `MyDataHelpsKit.xcodeproj`  into your app's Xcode workspace
-3. Open your app target's General settings tab in Xcode. In the project navigator pane, expand MyDataHelpsKit.xcodeproj > Products and drag MyDataHelpsKit.framework into the "Frameworks, Libraries, and Embedded Content" section 
+1. Download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases) from GitHub.
+2. From Finder, drag `MyDataHelpsKit.xcodeproj`  into your app's Xcode workspace.
+3. Open your app target's General settings tab in Xcode. In the project navigator pane, expand MyDataHelpsKit.xcodeproj > Products and drag MyDataHelpsKit.framework into the "Frameworks, Libraries, and Embedded Content" section.
 
 To update to a newer version of MyDataHelpsKit, download and unzip the [latest release](https://github.com/CareEvolution/MyDataHelpsKit-iOS/releases), and then delete and replace the existing MyDataHelpsKit folder structure in your workspace.

--- a/example/MyDataHelpsKit-Example/Session/SessionModel.swift
+++ b/example/MyDataHelpsKit-Example/Session/SessionModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import MyDataHelpsKit
 
-/// Produces a `ParticipantSession` object with a `ParticipantAccessToken` manually entered into the UI. See [documentation on Participant Tokens](https://developer.mydatahelps.org/sdk/participant_tokens.html) for information about obtaining an access token.
+/// Produces a `ParticipantSession` object with a `ParticipantAccessToken` manually entered into the UI. See [documentation on Participant Tokens](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for information about obtaining an access token.
 class SessionModel: ObservableObject {
     let client: MyDataHelpsClient
     @Published var token: String = ""

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 A SwiftUI app demonstrating usage of MyDataHelpsKit. For more information about the MyDataHelpsKit SDK, see the main [readme file](https://github.com/CareEvolution/MyDataHelpsKit-iOS).
 
-To get started, open `MyDataHelpsKit-Example.xcworkspace` in Xcode and run the app. Once the app launches, you will need to enter a valid participant token to authenticate and use the app's functionality. See [documentation on Participant Tokens](https://developer.mydatahelps.org/sdk/participant_tokens.html) for more information about obtaining an access token.
+To get started, open `MyDataHelpsKit-Example.xcworkspace` in Xcode and run the app. Once the app launches, you will need to enter a valid participant token to authenticate and use the app's functionality. See [documentation on Participant Tokens](https://developer.mydatahelps.org/embeddables/participant_tokens.html) for more information about obtaining an access token.
 
 Once you enter a participant token, the example app initializes a `ParticipantSession` and displays the RootMenuView, from which you can navigate to various other views to demonstrate each of the MyDataHelpsKit APIs.
 


### PR DESCRIPTION
## Overview

See #50. Don't merge until the updates to developer.mydatahelps.org referenced in that issue are published.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note:
    - No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
    - Xcode project/target settings should remain generic. Don't leak team identifiers, code signing info, local filesystem paths, etc.
- [X] My changes do not introduce any security risks, or any such risks have been properly mitigated.

## Checklist

- [X] All public symbols are documented using Swift Markup comments.
- [X] If this feature requires a developer doc update, tag `@CareEvolution/api-docs`
- [X] Source code file header comments are clean and standardized. Use "Created by CareEvolution on m/dd/yy".
- [X] Test and update the example app as needed. The example app should demonstrate all features of the SDK, and it's the most convenient way to test your feature.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
